### PR TITLE
Topic code style refactor and GPIO rework

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,191 @@
+---
+Language: Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands: Align
+SortIncludes: true
+InsertBraces: true # Control statements must have curly brackets
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortLambdasOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 150
+CommentPragmas: "^ IWYU pragma:"
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle: ""
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: "^<(.*)>"
+    Priority: 0
+  - Regex: '^"(.*)"'
+    Priority: 1
+  - Regex: "(.*)"
+    Priority: 2
+IncludeIsMainRegex: "(Test)?$"
+IncludeIsMainSourceRegex: ""
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth: -1
+ReferenceAlignment: Pointer
+ReflowComments: false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 1
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard: Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+---

--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AlignConsecutiveBitFields:
   Enabled: true
   AcrossEmptyLines: true
   AcrossComments: true
-AlignConsecutiveDeclarations: None
+AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Right
 AlignOperands: Align
 SortIncludes: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,10 @@
 
 get_directory_property(PLATFORM_DEFINED COMPILE_DEFINITIONS)
 if(PLATFORM_DEFINED MATCHES "^__SAMD21")
-    add_library(Universal_hall "hal/platform/atmelsam/atmel_default_irq_handlers.c"
+    add_library(Universal_hall "hal/platform/atmelsam/default_irq_handlers.c"
                                "hal/platform/atmelsam/gpio_samd.c"
-                               "hal/platform/atmelsam/i2c.c")
+                               "hal/platform/atmelsam/i2c.c"
+            hal/universal_hal.h)
     target_include_directories(Universal_hall PUBLIC "hal/" "utils/" "hal/platform/atmelsam/")
     target_link_libraries(Universal_hall INTERFACE board_sdk)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ if(PLATFORM_DEFINED MATCHES "^__SAMD21")
     add_library(Universal_hall "hal/platform/atmelsam/default_irq_handlers.c"
                                "hal/platform/atmelsam/gpio_samd.c"
                                "hal/platform/atmelsam/i2c.c"
-            hal/universal_hal.h)
+            hal/universal_hal.h
+            hal/platform/atmelsam/bit_manipulation.h)
     target_include_directories(Universal_hall PUBLIC "hal/" "utils/" "hal/platform/atmelsam/")
     target_link_libraries(Universal_hall INTERFACE board_sdk)
 else()

--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -1213,29 +1213,21 @@ Documented code allows doxygen to parse and generate html/pdf/latex output, thus
   * \brief           Template include file
   */
   /*
-  * Copyright (c) year FirstName LASTNAME
+  *  Copyright Year (C) FirstName LASTNAME <optional_email@example.com>
   *
-  * Permission is hereby granted, free of charge, to any person
-  * obtaining a copy of this software and associated documentation
-  * files (the "Software"), to deal in the Software without restriction,
-  * including without limitation the rights to use, copy, modify, merge,
-  * publish, distribute, sublicense, and/or sell copies of the Software,
-  * and to permit persons to whom the Software is furnished to do so,
-  * subject to the following conditions:
+  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  you may not use this file except in compliance with the License.
+  *  You may obtain a copy of the License at
   *
-  * The above copyright notice and this permission notice shall be
-  * included in all copies or substantial portions of the Software.
+  *  http://www.apache.org/licenses/LICENSE-2.0
   *
-  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
-  * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-  * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-  * OTHER DEALINGS IN THE SOFTWARE.
-  *
-  * This file is part of library_name.
+  *  Unless required by applicable law or agreed to in writing, software
+  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  See the License for the specific language governing permissions and
+  *  limitations under the License.
+  * 
+  * This file is part of the Universal Hal Framework.
   *
   * Author:          FirstName LASTNAME <optional_email@example.com>
   */

--- a/hal/gpio_error_handling.h
+++ b/hal/gpio_error_handling.h
@@ -1,18 +1,26 @@
+/**
+* \file            gpio_error_handling.h
+* \brief           Error handling for GPIO include file
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #ifndef GPIO_ERROR_HANDLING
 #define GPIO_ERROR_HANDLING

--- a/hal/gpio_error_handling.h
+++ b/hal/gpio_error_handling.h
@@ -24,9 +24,16 @@
 
 #ifndef GPIO_ERROR_HANDLING
 #define GPIO_ERROR_HANDLING
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef const char GPIO_ERR;
 
-enum GPIO_ERR_CODES {ERROR = -1, OK = 0};
+enum GPIO_ERR_CODES { ERROR = -1, OK = 0 };
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/hal_gpio.h
+++ b/hal/hal_gpio.h
@@ -21,7 +21,53 @@
 *
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
-
+/**
+ * The GPIO Module
+ *
+ * Possibilities:
+ * - Configuring the GPIO direction and pin-muxes (set_gpio_pin_mode)
+ * @note pin-mux and direction options differ for each microcontroller variant.
+ *       The enum name gpio_mode_t will still be the same. Keep this in mind.
+ * - Configuring the GPIO output level (set_gpio_pin_lvl)
+ * @note Some microcontrollers will support HIGH impedance mode. 
+ *       This will be incorporated in to the gpio_level_t enum.
+ * - Configuring GPIO options which are non-standard (like pull-ups, pull-downs, etc.)
+ * @note The non-standard gpio options differ for almost every other microcontroller variant.
+ * - Configuring GPIO interrupts
+ * @note For all the pins, one standard ISR handler is used (gpio_irq_handler). Keep this in mind.
+ * @note When implementing this gpio_irq_handler just implement the header in your source file like this:
+ * @code 
+ * void gpio_irq_handler(const void* const hw) {
+ * // Platform specific code to handle the request
+ * }
+ * @endcode
+ * - Reading GPIO input & output levels
+ * - Reading the GPIO pin-mux and direction options
+ * - Reading which non-standard gpio options are set
+ * 
+ * Impossibilities:
+ * - Although the interface is very generic, the ISR is fully dependent on platform specific code.
+ *   Keep this in mind when using the ISR.
+ * - To make implementations easier, the choice of having one ISR for all the pins was made.
+ *   This means that when you're setting multiple ISR's you need to read from the HW peripheral which
+ *   pins are triggered.
+ * @todo Maybe add a generic interface for the ISR, as some peripherals can be very complex to use.
+ * - Some microcontrollers have ERRATA issues, these might sill cause problems when using this module. 
+ *   When that is the case the problems will be listed on the wiki (https://hoog-v.github.io/Universal_hal/).
+ * - Some microcontrollers use pin numbers, others use a combination of numbers and letters 
+ *   and others use only numbers seperated with a dot (.). This module can't easily guess how to interpret the data.
+ *   Therefore a gpio_pin_t struct was brought in to life, which has a platform specific declaration for each mcu variant.
+ *   Just keep in mind that you have to make sure your pin declarations are up-to-date. 
+ *   Especially while porting between mcu variants.
+ * 
+ * Using this module:
+ * 1. Define a gpio pin: const gpio_pin_t blinky_led = {.port_name= <pin_number>,
+ *                                                      .pin_number=<pin_number>};
+ *    or depending on if your mcu only has pin numbers: const gpio_pin_t blinky_led = {.pin_number = <pin_number>};
+ * 2. Set the gpio pin mode: set_gpio_pin_mode(blinky_led, GPIO_MODE_OUTPUT);
+ * 3. Set the gpio pin level: set_gpio_pin_lvl(blinky_led, GPIO_HIGH);
+ *    or toggle the gpio: toggle_gpio_pin_output(blinky_led);
+ */
 #ifndef GPIO_HPP
 #define GPIO_HPP
 /* Extern c for compiling with c++*/

--- a/hal/hal_gpio.h
+++ b/hal/hal_gpio.h
@@ -1,18 +1,26 @@
+/**
+* \file            hal_gpio.h
+* \brief           GPIO module include file
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #ifndef GPIO_HPP
 #define GPIO_HPP

--- a/hal/hal_gpio.h
+++ b/hal/hal_gpio.h
@@ -39,9 +39,9 @@ void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode);
 
 void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level);
 
-const gpio_level_t get_gpio_pin_level(const gpio_pin_t pin);
+gpio_level_t get_gpio_pin_level(const gpio_pin_t pin);
 
-const gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin);
+gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin);
 
 void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt);
 

--- a/hal/hal_gpio.h
+++ b/hal/hal_gpio.h
@@ -32,22 +32,67 @@ extern "C" {
 #include <gpio_error_handling.h>
 #include <gpio_platform_specific.h>
 
+/**
+ * @brief Toggles output of given gpio pin.
+ * @param pin The pin to toggle
+ * @note Requires the pin to be set as output first.
+ */
 void toggle_gpio_pin_output(const gpio_pin_t pin);
 
+/**
+ * @brief Sets the gpio pin to INPUT,OUTPUT or special pin-mux functions (platform dependent).
+ * @param pin The pin to set to specific mode.
+ * @param pin_mode The pin mode to set the pin to.
+ */
 void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode);
 
+/**
+ * @brief Sets the gpio pin output level (HIGH, LOW, HIGH_IMPEDANCE (if supported) ).
+ * @param pin The pin to set the output level of.
+ * @param level The level: HIGH, LOW, etc...
+ */
 void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level);
 
+/**
+ * @brief Gets the current input level or set output level (depending on if pin is set to input or output direction).
+ * @param pin The pin to get the in/output level from.
+ * @return The in/output level of the pin.
+ */
 gpio_level_t get_gpio_pin_level(const gpio_pin_t pin);
 
+/**
+ * @brief Gets the currently set gpio pin-mode (INPUT, OUTPUT, e.g.).
+ * @param pin The pin to get the pin-mode from.
+ * @return The pin-mode of the pin.
+ */
 gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin);
 
+/**
+ * @brief Sets gpio pin options like pull-downs, pull-ups and driver strength among things.
+ * @param pin The pin to apply the new options to.
+ * @param opt The options to set.
+ */
 void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt);
 
+/**
+ * @brief Gets the currently set options for the specified pin.
+ * @param pin The pin to get the options from.
+ * @return The options set for the given pin.
+ */
 gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin);
 
+/**
+ * @brief Setup interrupts on the given pin.
+ * @param pin The pin on which the interrupt has to be triggered.
+ * @param irq_opt The options needed to setup the pin with interrupts (channels, trigger options (rising, falling, etc...), e.g. )
+ */
 void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt);
 
+/**
+ * @brief Default GPIO irq handler function.
+ * @param hw Pointer to the hw peripheral responsible for the IRQ (Depends on the platform used).
+ * @note To use it define this function in one of your own source files (main.c for example), this will override the default handler.
+ */
 void gpio_irq_handler(const void* const hw) __attribute__((weak));
 
 #ifdef __cplusplus

--- a/hal/hal_gpio.h
+++ b/hal/hal_gpio.h
@@ -24,48 +24,30 @@
 
 #ifndef GPIO_HPP
 #define GPIO_HPP
-#include <gpio_platform_specific.h>
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <gpio_error_handling.h>
-
-typedef enum {
-    kGPIODirInput,
-    kGPIODirOutput
-}GPIOPinDirection;
-
-typedef enum {
-    kGPIOLow,
-    kGPIOHigh,
-}GPIOPinLevel;
-
-#if SUPPORT_PIN_PULL
-void SetGPIOPull(const GPIOPin pin, GPIOPull PullMode);
-#endif
-
-#if SUPPORT_DRIVE_STRENGTH_SETTING
-void SetGPIOPinDriveStrength(const GPIOPin pin, GPIODriveStrength driver_strength);
-GPIODriveStrength GetGPIODriveStrength(const GPIOPin pin);
-#endif
+#include <gpio_platform_specific.h>
 
 
-#if SUPPORT_PINMUX
-void SetGPIOPinFunction(const GPIOPin pin, GPIOPinFunction pin_function);
-GPIOPinFunction GetGPIOPinFunction(const GPIOPin pin);
-#endif
+void toggle_gpio_pin_output(const gpio_pin_t pin);
 
-#if SUPPORT_PIN_SAMPLING_MODE_SELECT
-void SetGPIOPinSamplingMode(const GPIOPin pin, GPIOSamplingMode sampling_mode);
-#endif
+void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode);
 
-#if SUPPORT_PIN_TOGGLE
-void ToggleGPIOPin(const GPIOPin pin);
-#endif
+void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level);
 
-void SetGPIOPinDirection(const GPIOPin pin, const unsigned char direction);
+const gpio_level_t get_gpio_pin_level(const gpio_pin_t pin);
 
-void SetGPIOPinLevel(const GPIOPin pin, const unsigned char level);
+const gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin);
 
-GPIOPinDirection GetGPIOPinDirection(const GPIOPin pin);
+void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt);
 
-GPIOPinLevel GetGPIOPinLevel(GPIOPin pin);
+gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin);
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -79,7 +79,7 @@
  * const uint8_t reg_addr[2] = {0x02, 0x07};
  *
  * i2c_init(&i2c_periph, F_I2C_CLOCK);
- * i2c_write_blocking(&i2c_periph, CLIENT_DEVICE_I2C_ADDR, reg_addr, sizeof(reg_addr), 1);
+ * i2c_write_blocking(&i2c_periph, CLIENT_DEVICE_I2C_ADDR, reg_addr, sizeof(reg_addr), I2C_STOP_BIT);
  * uint8_t result;
  * i2c_read_blocking(&i2c_periph, CLIENT_DEVICE_I2C_ADDR, &result, sizeof(result));
  *@endcode
@@ -99,6 +99,11 @@ extern "C" {
 
 #include <stdbool.h>
 #include "i2c_platform_specific.h"
+
+typedef enum {
+    I2C_NO_STOP_BIT,
+    I2C_STOP_BIT
+}i2c_stop_bit_t;
 
 /**
  * @brief Function to initialize the specified HW peripheral with I2C functionality.
@@ -147,7 +152,7 @@ void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, unsigned short ad
  *                                                                       Value 0 is without stop-bit
  */
 void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, unsigned char addr, const unsigned char* write_buff, size_t size,
-                        unsigned char stop_bit);
+                        i2c_stop_bit_t stop_bit);
 
 /**
  * @brief Function to execute a write non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack them in a buffer or such)
@@ -160,7 +165,7 @@ void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, unsigned char add
  *                                                                       Value 0 is without stop-bit
  */
 void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, unsigned short addr, const unsigned char* write_buff, size_t size,
-                            unsigned char stop_bit);
+                            i2c_stop_bit_t stop_bit);
 
 /**
  * @brief Function to execute a read blocking transaction (blocking means it will wait till the transaction is finished)
@@ -188,12 +193,12 @@ void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, unsigned short
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *       and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *                    The info will be automatically supplied when using the i2c_write and i2c_read functions below
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_recv_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_master_data_recv_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C host data send interrupt.
@@ -201,12 +206,12 @@ void i2c_master_data_recv_irq(const void* hw, volatile bustransaction_t* Transac
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *        and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *                    The info will be automatically supplied when using the i2c_write and i2c_read functions below.
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_send_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_master_data_send_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client address match interrupt.
@@ -214,11 +219,11 @@ void i2c_master_data_send_irq(const void* hw, volatile bustransaction_t* Transac
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *        and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_address_match_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_address_match_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client stop interrupt.
@@ -226,11 +231,11 @@ void i2c_slave_address_match_irq(const void* hw, volatile bustransaction_t* Tran
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *        and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_stop_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_stop_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client receive interrupt.
@@ -238,11 +243,11 @@ void i2c_slave_stop_irq(const void* hw, volatile bustransaction_t* Transaction) 
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *        and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_recv_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_data_recv_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client send interrupt.
@@ -250,11 +255,11 @@ void i2c_slave_data_recv_irq(const void* hw, volatile bustransaction_t* Transact
  *        By defining this function inside a source file outside the Universal HALL, the default IRQ handler will be overridden
  *        and the compiler will automatically link your own custom implementation.
  * @param hw Handle to the HW peripheral on which the I2C bus is ran
- * @param Transaction I2C transaction info about the current initialized transaction on the HW peripheral.
+ * @param transaction I2C transaction info about the current initialized transaction on the HW peripheral.
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_send_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_data_send_irq(const void* hw, volatile bustransaction_t* transaction) __attribute__((weak));
 
 #ifdef __cplusplus
 }

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -21,6 +21,75 @@
 *
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
+/**
+ * The I2C module
+ *
+ * Possibilities:
+ * - Slave/Client and Master/Host functionality : Master means MCU as host and the connecting device as a slave device, with slave meaning the mcu is the connecting slave device.
+ * @note Host & Slave functionality is not supported by every hardware peripheral of every microcontroller variant.
+ *       The universal hal can't check whether your microcontroller supports this, please make sure that the microcontroller has
+ *       this feature and if the feature is supported by this hal, see wiki (https://hoog-v.github.io/Universal_hal/).
+ * @note Slave functionality is very difficult to implement with a generic api. Therefore this module only supports Slave functionality with
+ *       the interrupt functions listed below. The read_(non_)blocking and write_(non_)blocking functions do not work with this mode. Why?
+ *       Because every slave device has other functionality and way of interacting with the host. It is way easier to give the user of the library/framework
+ *       full control of the slave functionality, instead of abstracting away these interfaces in to write and read functions.
+ * - Blocking and non-blocking write and read functions for I2C host functionality.
+ * @note The write and read functions are implemented using interrupts. Keep in mind that this might mess with other timing-critical applications implemented
+ *       on the microcontroller.
+ * @note The implementation of non-blocking functions differ for each microcontroller variant. Some microcontroller variants have built-in functionality for
+ *       stacking transactions. Other microcontrollers don't have it and have to be implemented manually in software.
+ * - Setting different clock-frequencies for the I2C connection.
+ * @note The supported clock-frequencies are dependent on which frequencies are supported by the hardware peripheral of the microcontroller variant.
+ *       The I2C module doesn't check for this, you have to... Keep a eye on the datasheet of the MCU and the wiki (https://hoog-v.github.io/Universal_hal/).
+ *       Software bit-banged implementations of the I2C driver only support standard mode speeds (100KHz)
+ * - Linking your own custom interrupt handlers to this module for master as well as slave functionality.
+ * @note Linking custom implementations of i2c master irq functions will certainly break the write and read functions...
+ *       This is not the case if you facilitate the usage of the read and write functions in your custom implementation.
+ *       See the default handler in the default_irq_handlers.c file.
+ *
+ * Impossibilities:
+ * - Although the platform specific details have been abstracted away in to the i2c_periph_inst_t struct, you still have to manually configure this struct
+ *   with the right settings when porting between different microcontroller platforms.
+ * @note The recommended way to make porting easier is by making a general board_define file included with your main.c which has all the peripheral configurations and
+ *      pin_definitions defined. When porting the name of the structs will be the same, but the implementation details will differ, which means there will be only one place
+ *      to edit when porting.
+ * - Read and write functions for slave functionality. As said in the note above, every slave device is different. One is a big block of memory, while the other might be an active sensor.
+ *   It is very difficult to create a generic API that facilitates every possible slave device ever created. That's why only the IRQ handlers and init function work in this mode.
+ * @note The irq handlers trigger on the same moment in every device making porting easier.
+ * @note The irq handlers are weakly linked to the default handler, meaning that this might not be a misra compatible solution. But it is certainly better than passing callback function
+ *       pointers.
+ * - When using a microcontroller with extensive clock systems: Cortex-M based microcontrollers for example. The i2c module will not configure clock generators or other clock system options.
+ *   It might depending on the implementation of the init function link to an already configured clock generator listed in the i2c_periph_inst_t struct.
+ * - Due to the minimalistic interface there has not been a lot of error checking incorporated in the library... This is still an in progress.
+ * @todo add more error checking to the I2C module
+ * - The ISR handlers are shared among all hardware peripherals. It is very difficult to provide a separate handler for every hardware instance since this differs for every mcu variant.
+ *   The bustransaction_t struct helps to identify which peripheral it runs on. But keep this in mind.
+ * @todo add abstraction/default handler struct for ISR
+ *
+ * Using this module (Host mode):
+ * 1. Create a i2c_periph_inst_t <name> in your source file or board header file (recommended), with the settings needed for your microcontroller.
+ *    See the wiki(https://hoog-v.github.io/Universal_hal/) for which settings to configure and where to find them.
+ * 2. Run i2c_init(<name>, <i2c_clock_freq>), this will configure the peripheral with the needed settings to run in host mode.
+ * 3. Run any write or read request using the blocking (will wait till transaction is finished before running next line of code) or non-blocking (stack transactions and run them sequentially).
+ *
+ * Read a byte from reg 0x0207 from a connected sensor:
+ *@code
+ * #define F_I2C_CLOCK 100000
+ * #define CLIENT_DEVICE_I2C_ADDR 0x29
+ * const uint8_t reg_addr[2] = {0x02, 0x07};
+ *
+ * i2c_init(&i2c_periph, F_I2C_CLOCK);
+ * i2c_write_blocking(&i2c_periph, CLIENT_DEVICE_I2C_ADDR, reg_addr, sizeof(reg_addr), 1);
+ * uint8_t result;
+ * i2c_read_blocking(&i2c_periph, CLIENT_DEVICE_I2C_ADDR, &result, sizeof(result));
+ *@endcode
+ *
+ * Using this module (Slave mode):
+ * 1. Create a i2c_periph_inst_t <name> in your source file or board header file (recommended), with the settings needed for your microcontroller.
+ *    See the wiki(https://hoog-v.github.io/Universal_hal/) for which settings to configure and where to find them.
+ * 2. Run i2c_init(<name>, 0), this will configure the peripheral with the needed settings to run in slave mode.
+ * 3. Implement some of the slave IRQ functions, to match your use case.
+ */
 #ifndef HAL_I2C_H
 #define HAL_I2C_H
 /* Extern c for compiling with c++*/
@@ -28,8 +97,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include "i2c_platform_specific.h"
 #include <stdbool.h>
+#include "i2c_platform_specific.h"
 
 /**
  * @brief Function to initialize the specified HW peripheral with I2C functionality.
@@ -43,9 +112,9 @@ extern "C" {
  *                                                     HW peripheral instance number
  *                                                     HW peripheral handle
  *
- * @param baudrate The I2C Clock frequency to be used in transactions (only used in host mode)
+ * @param baud_rate The I2C Clock frequency to be used in transactions (only used in host mode, when in slave mode every value will be discarded)
  */
-void i2c_init(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate);
+void i2c_init(const i2c_periph_inst_t* i2c_instance, unsigned long baud_rate);
 
 /**
  * @brief Function to de-initialize the specified HW peripheral (disables I2C on the HW peripheral).
@@ -56,16 +125,16 @@ void i2c_deinit(const i2c_periph_inst_t* i2c_instance);
 /**
  * @brief Function to set the baud-rate after the peripheral has been initialized with I2C.
  * @param i2c_instance I2C options used when configuring the HW peripheral.
- * @param baudrate The I2C Clock frequency to be used in transactions (only used in host mode)
+ * @param baud_rate The I2C Clock frequency to be used in transactions (only used in host mode)
  */
-void i2c_set_baudrate(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate);
+void i2c_set_baud_rate(const i2c_periph_inst_t* i2c_instance, unsigned long baud_rate);
 
 /**
  * @brief Function to enable slave mode after the peripheral has already been initialized in host-mode
  * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C slave address to used
  */
-void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, const unsigned short addr);
+void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, unsigned short addr);
 
 /**
  * @brief Function to execute a write blocking transaction (blocking means it will wait till the transaction is finished)
@@ -77,8 +146,8 @@ void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, const unsigned sh
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr,
-                        const unsigned char* write_buff, const unsigned char size, bool stop_bit);
+void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, unsigned char addr, const unsigned char* write_buff, size_t size,
+                        unsigned char stop_bit);
 
 /**
  * @brief Function to execute a write non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack them in a buffer or such)
@@ -90,8 +159,8 @@ void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned ch
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr,
-                            const unsigned char* write_buff, const unsigned char size, bool stop_bit);
+void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, unsigned short addr, const unsigned char* write_buff, size_t size,
+                            unsigned char stop_bit);
 
 /**
  * @brief Function to execute a read blocking transaction (blocking means it will wait till the transaction is finished)
@@ -101,8 +170,7 @@ void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigne
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff,
-                       const unsigned char amount_of_bytes);
+void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, unsigned short addr, unsigned char* read_buff, size_t amount_of_bytes);
 
 /**
  * @brief Function to execute a read non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack the transactions in to a buffer)
@@ -112,8 +180,7 @@ void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned sho
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff,
-                           const unsigned char amount_of_bytes);
+void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, unsigned short addr, unsigned char* read_buff, size_t amount_of_bytes);
 
 /**
  * @brief IRQ handler for I2C host data receive interrupt.
@@ -126,7 +193,7 @@ void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_master_data_recv_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C host data send interrupt.
@@ -139,7 +206,7 @@ void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* T
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_master_data_send_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client address match interrupt.
@@ -151,7 +218,7 @@ void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* T
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_address_match_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client stop interrupt.
@@ -163,7 +230,7 @@ void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_stop_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_stop_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client receive interrupt.
@@ -175,7 +242,7 @@ void i2c_slave_stop_irq(const void* const hw, volatile bustransaction_t* Transac
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_data_recv_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client send interrupt.
@@ -187,7 +254,7 @@ void i2c_slave_data_recv_irq(const void* const hw, volatile bustransaction_t* Tr
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
+void i2c_slave_data_send_irq(const void* hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 #ifdef __cplusplus
 }

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -23,6 +23,11 @@
 */
 #ifndef HAL_I2C_H
 #define HAL_I2C_H
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <i2c_platform_specific.h>
 #include <stdbool.h>
 
@@ -72,7 +77,8 @@ void i2c_set_slave_mode(const i2c_periph_inst_t* I2C_instance, const unsigned sh
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned char addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit);
+void i2c_write_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned char addr,
+                        const unsigned char* write_buff, const unsigned char size, bool stop_bit);
 
 /**
  * @brief Function to execute a write non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack them in a buffer or such)
@@ -84,7 +90,8 @@ void i2c_write_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned ch
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit);
+void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr,
+                            const unsigned char* write_buff, const unsigned char size, bool stop_bit);
 
 /**
  * @brief Function to execute a read blocking transaction (blocking means it will wait till the transaction is finished)
@@ -94,7 +101,8 @@ void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigne
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes);
+void i2c_read_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff,
+                       const unsigned char amount_of_bytes);
 
 /**
  * @brief Function to execute a read non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack the transactions in to a buffer)
@@ -104,7 +112,8 @@ void i2c_read_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned sho
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes);
+void i2c_read_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff,
+                           const unsigned char amount_of_bytes);
 
 /**
  * @brief IRQ handler for I2C host data receive interrupt.
@@ -117,7 +126,7 @@ void i2c_read_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_recv_irq(const void *const hw, volatile bustransaction_t *Transaction) __attribute__((weak));
+void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C host data send interrupt.
@@ -130,7 +139,7 @@ void i2c_master_data_recv_irq(const void *const hw, volatile bustransaction_t *T
  *
  * @note Using your own custom IRQ handler might break the use of the write and read functions listed above
  */
-void i2c_master_data_send_irq(const void *const hw, volatile bustransaction_t *Transaction) __attribute__((weak));
+void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client address match interrupt.
@@ -142,7 +151,7 @@ void i2c_master_data_send_irq(const void *const hw, volatile bustransaction_t *T
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_address_match_irq(const void *const hw, volatile bustransaction_t *Transaction)  __attribute__((weak)) ;
+void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client stop interrupt.
@@ -154,7 +163,7 @@ void i2c_slave_address_match_irq(const void *const hw, volatile bustransaction_t
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_stop_irq(const void *const hw, volatile bustransaction_t *Transaction)  __attribute__((weak)) ;
+void i2c_slave_stop_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client receive interrupt.
@@ -166,7 +175,7 @@ void i2c_slave_stop_irq(const void *const hw, volatile bustransaction_t *Transac
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_recv_irq(const void *const hw, volatile bustransaction_t *Transaction)  __attribute__((weak)) ;
+void i2c_slave_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
 /**
  * @brief IRQ handler for I2C Client send interrupt.
@@ -178,8 +187,9 @@ void i2c_slave_data_recv_irq(const void *const hw, volatile bustransaction_t *Tr
  *
  *  @note I2C Slave functionality doesn't use the read/write functions below
  */
-void i2c_slave_data_send_irq(const void *const hw, volatile bustransaction_t *Transaction)  __attribute__((weak)) ;
+void i2c_slave_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) __attribute__((weak));
 
-
-
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -51,68 +51,68 @@ void i2c_init(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrat
  * @brief Function to de-initialize the specified HW peripheral (disables I2C on the HW peripheral).
  * @param i2c_instance I2C options used when configuring the HW peripheral.
  */
-void i2c_deinit(const i2c_periph_inst_t* I2C_instance);
+void i2c_deinit(const i2c_periph_inst_t* i2c_instance);
 
 /**
  * @brief Function to set the baud-rate after the peripheral has been initialized with I2C.
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param baudrate The I2C Clock frequency to be used in transactions (only used in host mode)
  */
-void i2c_set_baudrate(const i2c_periph_inst_t* I2C_instance, const unsigned long baudrate);
+void i2c_set_baudrate(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate);
 
 /**
  * @brief Function to enable slave mode after the peripheral has already been initialized in host-mode
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C slave address to used
  */
-void i2c_set_slave_mode(const i2c_periph_inst_t* I2C_instance, const unsigned short addr);
+void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, const unsigned short addr);
 
 /**
  * @brief Function to execute a write blocking transaction (blocking means it will wait till the transaction is finished)
  *        This function does only work in host-mode.
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C address of the client device to write to
  * @param write_buff Pointer to the write buffer with all the bytes that have to be written
  * @param size The amount of bytes which have to be written
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned char addr,
+void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr,
                         const unsigned char* write_buff, const unsigned char size, bool stop_bit);
 
 /**
  * @brief Function to execute a write non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack them in a buffer or such)
  *        This function does only work in host-mode.
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C address of the client device to write to
  * @param write_buff Pointer to the write buffer with all the bytes that have to be written
  * @param size The amount of bytes which have to be written
  * @param stop_bit Does this transaction end with or without a stop-bit: Value 1 is with stop-bit
  *                                                                       Value 0 is without stop-bit
  */
-void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr,
+void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr,
                             const unsigned char* write_buff, const unsigned char size, bool stop_bit);
 
 /**
  * @brief Function to execute a read blocking transaction (blocking means it will wait till the transaction is finished)
  *        This function does only work in host-mode.
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C address of the client device to write to
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff,
+void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff,
                        const unsigned char amount_of_bytes);
 
 /**
  * @brief Function to execute a read non-blocking transaction (non-blocking means it will not wait till the transaction is finished and stack the transactions in to a buffer)
  *        This function does only work in host-mode.
- * @param I2C_instance I2C options used when configuring the HW peripheral.
+ * @param i2c_instance I2C options used when configuring the HW peripheral.
  * @param addr The I2C address of the client device to write to
  * @param read_buff Pointer to the read buffer where all read bytes will be written
  * @param amount_of_bytes The amount of bytes which have to be read
  */
-void i2c_read_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff,
+void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff,
                            const unsigned char amount_of_bytes);
 
 /**

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -97,7 +97,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <stdbool.h>
 #include "i2c_platform_specific.h"
 
 typedef enum {

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -1,19 +1,26 @@
+/**
+* \file            hal_i2c.h
+* \brief           I2C module include file
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 #ifndef HAL_I2C_H
 #define HAL_I2C_H
 #include <i2c_platform_specific.h>

--- a/hal/hal_i2c.h
+++ b/hal/hal_i2c.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <i2c_platform_specific.h>
+#include "i2c_platform_specific.h"
 #include <stdbool.h>
 
 /**

--- a/hal/platform/atmelsam/bit_manipulation.h
+++ b/hal/platform/atmelsam/bit_manipulation.h
@@ -1,6 +1,6 @@
 /**
-* \file            hal_gpio.h
-* \brief           GPIO module include file
+* \file            bit_manipulation.h
+* \brief           Header file with useful macro's for bit manipulation
 */
 /*
 *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
@@ -22,35 +22,23 @@
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
 
-#ifndef GPIO_HPP
-#define GPIO_HPP
+#ifndef ATMELSAMD21_BIT_MANIPULATION_H
+#define ATMELSAMD21_BIT_MANIPULATION_H
 /* Extern c for compiling with c++*/
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-#include <gpio_error_handling.h>
-#include <gpio_platform_specific.h>
+#define BITMASK_COMPARE(NUM, MASK)       (NUM & MASK)
+#define BIT_IS_SET(VAL, BIT_NUM)         (VAL >> BIT_NUM) & 1
+#define SHIFT_ONE_LEFT_BY_N(N)           1 << N
 
-void toggle_gpio_pin_output(const gpio_pin_t pin);
+#define GET_LOWER_4_BITS_OF_BYTE(x)      BITMASK_COMPARE(x, 0xF)
+#define GET_UPPER_4_BITS_OF_BYTE(x)      BITMASK_COMPARE((x >> 4), 0xF)
 
-void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode);
-
-void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level);
-
-gpio_level_t get_gpio_pin_level(const gpio_pin_t pin);
-
-gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin);
-
-void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt);
-
-gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin);
-
-void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt);
-
-void gpio_irq_handler(const void* const hw) __attribute__((weak));
+#define PIN_IS_EVEN_NUMBER(x)            (x % 2) == 0
 
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif
+#endif //ATMELSAMD21_BIT_MANIPULATION_H

--- a/hal/platform/atmelsam/default_irq_handlers.c
+++ b/hal/platform/atmelsam/default_irq_handlers.c
@@ -49,23 +49,23 @@ volatile bustransaction_t SercomBusTrans[6] = {{SERCOMACT_NONE, 0, NULL, NULL, 0
 /**
  * @brief Default IRQ Handler for the I2C master data send interrupt
  * @param hw Pointer to the HW peripheral to be manipulated
- * @param Transaction The current transaction information
+ * @param transaction The current transaction information
  */
-void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) {
+void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* transaction) {
     Sercom*    sercom_instance = ((Sercom*)hw);
-    const bool write_buffer_exists = (Transaction->write_buffer != NULL);
-    const bool has_bytes_left_to_write = (Transaction->buf_cnt < Transaction->buf_size);
+    const bool write_buffer_exists = (transaction->write_buffer != NULL);
+    const bool has_bytes_left_to_write = (transaction->buf_cnt < transaction->buf_size);
     if (write_buffer_exists && has_bytes_left_to_write) {
-        sercom_instance->I2CM.DATA.reg = Transaction->write_buffer[Transaction->buf_cnt++];
+        sercom_instance->I2CM.DATA.reg = transaction->write_buffer[transaction->buf_cnt++];
     } else {
-        const bool send_stop_bit = (Transaction->transaction_type != SERCOMACT_I2C_DATA_TRANSMIT_NO_STOP);
+        const bool send_stop_bit = (transaction->transaction_type != SERCOMACT_I2C_DATA_TRANSMIT_NO_STOP);
         if (send_stop_bit) {
             sercom_instance->I2CM.CTRLB.reg = SERCOM_I2C_MASTER_NACK_AND_STOP;
         } else {
             sercom_instance->I2CM.INTFLAG.reg = SERCOM_I2CM_INTFLAG_MB;
         }
-        Transaction->transaction_type = SERCOMACT_IDLE_I2CM;
-        Transaction->buf_cnt = 0;
+        transaction->transaction_type = SERCOMACT_IDLE_I2CM;
+        transaction->buf_cnt = 0;
     }
 }
 
@@ -84,21 +84,21 @@ void i2c_slave_stop_irq(const void* const hw, volatile bustransaction_t* Transac
     Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
 
-void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t* Transaction) {
+void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t* transaction) {
     ((Sercom*)hw)->I2CS.INTFLAG.reg = SERCOM_I2CS_INTFLAG_AMATCH;
-    Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
+    transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
 
-void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) {
+void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* transaction) {
     Sercom* sercom_instance = ((Sercom*)hw);
-    if (Transaction->read_buffer != NULL && Transaction->buf_cnt < Transaction->buf_size) {
-        Transaction->read_buffer[Transaction->buf_cnt++] = sercom_instance->I2CM.DATA.reg;
-        const bool last_byte_read = Transaction->buf_cnt >= Transaction->buf_size;
+    if (transaction->read_buffer != NULL && transaction->buf_cnt < transaction->buf_size) {
+        transaction->read_buffer[transaction->buf_cnt++] = sercom_instance->I2CM.DATA.reg;
+        const bool last_byte_read = transaction->buf_cnt >= transaction->buf_size;
         sercom_instance->I2CM.CTRLB.reg = last_byte_read ? SERCOM_I2C_MASTER_NACK_AND_STOP : SERCOM_I2C_MASTER_RECV_ACK_AND_REQ_NEW_BYTE;
     } else {
         sercom_instance->I2CM.CTRLB.reg = SERCOM_I2C_MASTER_NACK_AND_STOP;
-        Transaction->transaction_type = SERCOMACT_IDLE_I2CM;
-        Transaction->buf_cnt = 0;
+        transaction->transaction_type = SERCOMACT_IDLE_I2CM;
+        transaction->buf_cnt = 0;
     }
 }
 

--- a/hal/platform/atmelsam/default_irq_handlers.c
+++ b/hal/platform/atmelsam/default_irq_handlers.c
@@ -32,7 +32,7 @@
  *        This will eventually be replaced with a ringbuffer implementation
  *        so the non-blocking functions can function as they should.
  *
- * @TODO Replace this implementation with a ringbuffer
+ * @todo Replace this implementation with a ringbuffer
  */
 volatile bustransaction_t SercomBusTrans[6] = {{SERCOMACT_NONE, 0, NULL, NULL, 0, 0}, {SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
                                                {SERCOMACT_NONE, 0, NULL, NULL, 0, 0}, {SERCOMACT_NONE, 0, NULL, NULL, 0, 0},

--- a/hal/platform/atmelsam/default_irq_handlers.c
+++ b/hal/platform/atmelsam/default_irq_handlers.c
@@ -21,11 +21,11 @@
 *
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
-
+#include "default_irq_handlers.h"
+#include "hal_i2c.h"
+#include "hal_gpio.h"
+#include "i2c_platform_specific.h"
 #include <stdbool.h>
-#include <i2c_platform_specific.h>
-#include <default_irq_handlers.h>
-#include <hal_i2c.h>
 
 /**
  * @brief Each SERCOM peripheral gets its own SercomBusTransaction.
@@ -34,12 +34,9 @@
  *
  * @TODO Replace this implementation with a ringbuffer
  */
-volatile bustransaction_t  SercomBusTrans[6] = {{SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
-{SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
-{SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
-{SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
-{SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
-{SERCOMACT_NONE, 0, NULL, NULL, 0, 0}};
+volatile bustransaction_t SercomBusTrans[6] = {{SERCOMACT_NONE, 0, NULL, NULL, 0, 0}, {SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
+                                               {SERCOMACT_NONE, 0, NULL, NULL, 0, 0}, {SERCOMACT_NONE, 0, NULL, NULL, 0, 0},
+                                               {SERCOMACT_NONE, 0, NULL, NULL, 0, 0}, {SERCOMACT_NONE, 0, NULL, NULL, 0, 0}};
 
 /**
  * @brief Macros used in ISR for acknowledging and finishing the transaction
@@ -47,23 +44,22 @@ volatile bustransaction_t  SercomBusTrans[6] = {{SERCOMACT_NONE, 0, NULL, NULL, 
  * SERCOM_I2C_MASTER_NACK_AND_STOP will send a NACK to the slave device and stops the transaction by sending a stop bit.
  */
 #define SERCOM_I2C_MASTER_RECV_ACK_AND_REQ_NEW_BYTE SERCOM_I2CM_CTRLB_CMD(2) | SERCOM_I2CM_CTRLB_SMEN
-#define SERCOM_I2C_MASTER_NACK_AND_STOP  SERCOM_I2CM_CTRLB_CMD(3) | SERCOM_I2CM_CTRLB_ACKACT | SERCOM_I2CM_CTRLB_SMEN
-
+#define SERCOM_I2C_MASTER_NACK_AND_STOP             SERCOM_I2CM_CTRLB_CMD(3) | SERCOM_I2CM_CTRLB_ACKACT | SERCOM_I2CM_CTRLB_SMEN
 
 /**
  * @brief Default IRQ Handler for the I2C master data send interrupt
  * @param hw Pointer to the HW peripheral to be manipulated
  * @param Transaction The current transaction information
  */
-void i2c_master_data_send_irq(const void *const hw, volatile bustransaction_t* Transaction ) {
-    Sercom* sercom_instance = ((Sercom*)hw);
+void i2c_master_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) {
+    Sercom*    sercom_instance = ((Sercom*)hw);
     const bool write_buffer_exists = (Transaction->write_buffer != NULL);
     const bool has_bytes_left_to_write = (Transaction->buf_cnt < Transaction->buf_size);
-    if(write_buffer_exists && has_bytes_left_to_write) {
+    if (write_buffer_exists && has_bytes_left_to_write) {
         sercom_instance->I2CM.DATA.reg = Transaction->write_buffer[Transaction->buf_cnt++];
     } else {
         const bool send_stop_bit = (Transaction->transaction_type != SERCOMACT_I2C_DATA_TRANSMIT_NO_STOP);
-        if(send_stop_bit){
+        if (send_stop_bit) {
             sercom_instance->I2CM.CTRLB.reg = SERCOM_I2C_MASTER_NACK_AND_STOP;
         } else {
             sercom_instance->I2CM.INTFLAG.reg = SERCOM_I2CM_INTFLAG_MB;
@@ -73,28 +69,29 @@ void i2c_master_data_send_irq(const void *const hw, volatile bustransaction_t* T
     }
 }
 
-void i2c_slave_data_recv_irq(const void *const hw, volatile bustransaction_t* Transaction) {
+void i2c_slave_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) {
     ((Sercom*)hw)->I2CS.INTFLAG.reg = SERCOM_I2CS_INTFLAG_DRDY;
     Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
 
-void i2c_slave_data_send_irq(const void *const hw, volatile bustransaction_t* Transaction) {
+void i2c_slave_data_send_irq(const void* const hw, volatile bustransaction_t* Transaction) {
     ((Sercom*)hw)->I2CS.INTFLAG.reg = SERCOM_I2CS_INTFLAG_DRDY;
     Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
 
-void i2c_slave_stop_irq(const void *const hw, volatile bustransaction_t* Transaction) {
+void i2c_slave_stop_irq(const void* const hw, volatile bustransaction_t* Transaction) {
     ((Sercom*)hw)->I2CS.INTFLAG.reg = SERCOM_I2CS_INTFLAG_PREC;
     Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
-void i2c_slave_address_match_irq(const void *const hw, volatile bustransaction_t* Transaction) {
+
+void i2c_slave_address_match_irq(const void* const hw, volatile bustransaction_t* Transaction) {
     ((Sercom*)hw)->I2CS.INTFLAG.reg = SERCOM_I2CS_INTFLAG_AMATCH;
     Transaction->transaction_type = SERCOMACT_IDLE_I2CS;
 }
 
-void i2c_master_data_recv_irq(const void *const hw, volatile bustransaction_t* Transaction){
+void i2c_master_data_recv_irq(const void* const hw, volatile bustransaction_t* Transaction) {
     Sercom* sercom_instance = ((Sercom*)hw);
-    if(Transaction->read_buffer != NULL && Transaction->buf_cnt < Transaction->buf_size) {
+    if (Transaction->read_buffer != NULL && Transaction->buf_cnt < Transaction->buf_size) {
         Transaction->read_buffer[Transaction->buf_cnt++] = sercom_instance->I2CM.DATA.reg;
         const bool last_byte_read = Transaction->buf_cnt >= Transaction->buf_size;
         sercom_instance->I2CM.CTRLB.reg = last_byte_read ? SERCOM_I2C_MASTER_NACK_AND_STOP : SERCOM_I2C_MASTER_RECV_ACK_AND_REQ_NEW_BYTE;
@@ -105,88 +102,98 @@ void i2c_master_data_recv_irq(const void *const hw, volatile bustransaction_t* T
     }
 }
 
-void i2c_slave_handler(const void *const hw, volatile bustransaction_t* Transaction) {
-    Sercom* sercom_instance = ((Sercom*)hw);
+void i2c_slave_handler(const void* const hw, volatile bustransaction_t* Transaction) {
+    Sercom*    sercom_instance = ((Sercom*)hw);
     const bool addressMatchInt = sercom_instance->I2CS.INTFLAG.reg & SERCOM_I2CS_INTFLAG_AMATCH;
     const bool stopInt = sercom_instance->I2CS.INTFLAG.reg & SERCOM_I2CS_INTFLAG_PREC;
     const bool dataReadyInt = sercom_instance->I2CS.INTFLAG.reg & SERCOM_I2CS_INTFLAG_DRDY;
     const bool isReadTransaction = sercom_instance->I2CS.STATUS.bit.DIR;
-    if(addressMatchInt) {
+    if (addressMatchInt) {
         i2c_slave_address_match_irq(hw, Transaction);
     }
-    if(stopInt) {
+    if (stopInt) {
         i2c_slave_stop_irq(hw, Transaction);
     }
-    if(dataReadyInt && isReadTransaction) {
+    if (dataReadyInt && isReadTransaction) {
         i2c_slave_data_send_irq(hw, Transaction);
     }
-    if(dataReadyInt && !isReadTransaction) {
+    if (dataReadyInt && !isReadTransaction) {
         i2c_slave_data_recv_irq(hw, Transaction);
     }
 }
 
-__attribute__((used)) void SERCOM5_Handler(void)
-{
-    if(SERCOM5->I2CM.INTFLAG.bit.SB) {
+void gpio_irq_handler(const void* const hw) {
+    Eic *           eic_inst = (Eic*) hw;
+    const uint32_t  intflag_val = eic_inst->INTFLAG.reg;
+    eic_inst->INTFLAG.reg = intflag_val;
+    const uint32_t nmi_intflag_val = eic_inst->NMIFLAG.reg;
+    eic_inst->NMIFLAG.reg = nmi_intflag_val;
+}
+
+__attribute__((used)) void SERCOM5_Handler(void) {
+    if (SERCOM5->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM5, &SercomBusTrans[5]);
     } else if (SERCOM5->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM5, &SercomBusTrans[5]);
-    } else if(SERCOM5->I2CS.INTFLAG.bit.AMATCH || SERCOM5->I2CS.INTFLAG.bit.DRDY || SERCOM5->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM5->I2CS.INTFLAG.bit.AMATCH || SERCOM5->I2CS.INTFLAG.bit.DRDY || SERCOM5->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM5, &SercomBusTrans[5]);
     }
 }
 
-__attribute__((used)) void SERCOM4_Handler(void)
-{
-    if(SERCOM4->I2CM.INTFLAG.bit.SB) {
+__attribute__((used)) void SERCOM4_Handler(void) {
+    if (SERCOM4->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM4, &SercomBusTrans[4]);
     } else if (SERCOM4->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM4, &SercomBusTrans[4]);
-    } else if(SERCOM4->I2CS.INTFLAG.bit.AMATCH || SERCOM4->I2CS.INTFLAG.bit.DRDY || SERCOM4->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM4->I2CS.INTFLAG.bit.AMATCH || SERCOM4->I2CS.INTFLAG.bit.DRDY || SERCOM4->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM4, &SercomBusTrans[4]);
     }
 }
 
-__attribute__((used)) void SERCOM3_Handler(void)
-{
-    if(SERCOM3->I2CM.INTFLAG.bit.SB) {
+__attribute__((used)) void SERCOM3_Handler(void) {
+    if (SERCOM3->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM3, &SercomBusTrans[3]);
     } else if (SERCOM3->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM3, &SercomBusTrans[3]);
-    } else if(SERCOM3->I2CS.INTFLAG.bit.AMATCH || SERCOM3->I2CS.INTFLAG.bit.DRDY || SERCOM3->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM3->I2CS.INTFLAG.bit.AMATCH || SERCOM3->I2CS.INTFLAG.bit.DRDY || SERCOM3->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM3, &SercomBusTrans[3]);
     }
 }
 
-__attribute__((used)) void SERCOM2_Handler(void)
-{
-    if(SERCOM2->I2CM.INTFLAG.bit.SB) {
+__attribute__((used)) void SERCOM2_Handler(void) {
+    if (SERCOM2->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM2, &SercomBusTrans[2]);
     } else if (SERCOM2->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM2, &SercomBusTrans[2]);
-    } else if(SERCOM2->I2CS.INTFLAG.bit.AMATCH || SERCOM2->I2CS.INTFLAG.bit.DRDY || SERCOM2->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM2->I2CS.INTFLAG.bit.AMATCH || SERCOM2->I2CS.INTFLAG.bit.DRDY || SERCOM2->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM2, &SercomBusTrans[2]);
     }
 }
 
-__attribute__((used)) void SERCOM1_Handler(void)
-{
-    if(SERCOM1->I2CM.INTFLAG.bit.SB) {
+__attribute__((used)) void SERCOM1_Handler(void) {
+    if (SERCOM1->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM1, &SercomBusTrans[1]);
     } else if (SERCOM1->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM1, &SercomBusTrans[1]);
-    } else if(SERCOM1->I2CS.INTFLAG.bit.AMATCH || SERCOM1->I2CS.INTFLAG.bit.DRDY || SERCOM1->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM1->I2CS.INTFLAG.bit.AMATCH || SERCOM1->I2CS.INTFLAG.bit.DRDY || SERCOM1->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM1, &SercomBusTrans[1]);
     }
 }
 
-__attribute__((used)) void SERCOM0_Handler(void)
-{
-    if(SERCOM0->I2CM.INTFLAG.bit.SB) {
+__attribute__((used)) void SERCOM0_Handler(void) {
+    if (SERCOM0->I2CM.INTFLAG.bit.SB) {
         i2c_master_data_recv_irq(SERCOM0, &SercomBusTrans[0]);
     } else if (SERCOM0->I2CM.INTFLAG.bit.MB) {
         i2c_master_data_send_irq(SERCOM0, &SercomBusTrans[0]);
-    } else if(SERCOM0->I2CS.INTFLAG.bit.AMATCH || SERCOM0->I2CS.INTFLAG.bit.DRDY || SERCOM0->I2CS.INTFLAG.bit.PREC) {
+    } else if (SERCOM0->I2CS.INTFLAG.bit.AMATCH || SERCOM0->I2CS.INTFLAG.bit.DRDY || SERCOM0->I2CS.INTFLAG.bit.PREC) {
         i2c_slave_handler(SERCOM0, &SercomBusTrans[0]);
     }
+}
+
+__attribute__((used)) void EIC_Handler(void) {
+    gpio_irq_handler(EIC);
+}
+
+__attribute__((used)) void NonMaskableInt_Handler(void) {
+    gpio_irq_handler(EIC);
 }

--- a/hal/platform/atmelsam/default_irq_handlers.c
+++ b/hal/platform/atmelsam/default_irq_handlers.c
@@ -1,22 +1,30 @@
+/**
+* \file            default_irq_handlers.c
+* \brief           Source file with default interrupt handlers for MICROCHIP SAM peripherals
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #include <stdbool.h>
 #include <i2c_platform_specific.h>
-#include <atmel_default_irq_handlers.h>
+#include <default_irq_handlers.h>
 #include <hal_i2c.h>
 
 /**

--- a/hal/platform/atmelsam/default_irq_handlers.h
+++ b/hal/platform/atmelsam/default_irq_handlers.h
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
-#ifndef ATMELSAMD21_ATMEL_DEFAULT_IRQ_HANDLERS_H
-#define ATMELSAMD21_ATMEL_DEFAULT_IRQ_HANDLERS_H
+#ifndef ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H
+#define ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H
 
 void SERCOM0_Handler(void) __attribute__((used));
 void SERCOM1_Handler(void) __attribute__((used));
@@ -25,4 +25,4 @@ void SERCOM4_Handler(void) __attribute__((used));
 void SERCOM5_Handler(void) __attribute__((used));
 
 extern volatile bustransaction_t SercomBusTrans[6];
-#endif //ATMELSAMD21_ATMEL_DEFAULT_IRQ_HANDLERS_H
+#endif //ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H

--- a/hal/platform/atmelsam/default_irq_handlers.h
+++ b/hal/platform/atmelsam/default_irq_handlers.h
@@ -16,6 +16,10 @@
 
 #ifndef ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H
 #define ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 void SERCOM0_Handler(void) __attribute__((used));
 void SERCOM1_Handler(void) __attribute__((used));
@@ -25,4 +29,8 @@ void SERCOM4_Handler(void) __attribute__((used));
 void SERCOM5_Handler(void) __attribute__((used));
 
 extern volatile bustransaction_t SercomBusTrans[6];
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif //ATMELSAMD21_DEFAULT_IRQ_HANDLERS_H

--- a/hal/platform/atmelsam/default_irq_handlers.h
+++ b/hal/platform/atmelsam/default_irq_handlers.h
@@ -21,12 +21,16 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "i2c_platform_specific.h"
+
 void SERCOM0_Handler(void) __attribute__((used));
 void SERCOM1_Handler(void) __attribute__((used));
 void SERCOM2_Handler(void) __attribute__((used));
 void SERCOM3_Handler(void) __attribute__((used));
 void SERCOM4_Handler(void) __attribute__((used));
 void SERCOM5_Handler(void) __attribute__((used));
+void EIC_Handler(void);
+void NonMaskableInt_Handler(void);
 
 extern volatile bustransaction_t SercomBusTrans[6];
 

--- a/hal/platform/atmelsam/gpio_platform_specific.h
+++ b/hal/platform/atmelsam/gpio_platform_specific.h
@@ -1,18 +1,26 @@
+/**
+* \file            gpio_platform_specific.h
+* \brief           Include file with peripheral specific settings for the GPIO module
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #ifndef GPIO_PLATFORM_SPECIFIC
 #define GPIO_PLATFORM_SPECIFIC

--- a/hal/platform/atmelsam/gpio_platform_specific.h
+++ b/hal/platform/atmelsam/gpio_platform_specific.h
@@ -29,13 +29,30 @@
 extern "C" {
 #endif /* __cplusplus */
 
+/**
+ * @brief The SAMD series support two GPIO levels,
+ *        LOW AND HIGH... Use this when using the
+ *        set_gpio_pin_level() or get_gpio_pin_level() functions.
+ */
 typedef enum {
     GPIO_LOW,
     GPIO_HIGH,
 } gpio_level_t;
 
-typedef enum { GPIO_PORT_A, GPIO_PORT_B, GPIO_PORT_C } gpio_port_t;
+/**
+ * @brief The SAMD series have a minimum of two GPIO ports.
+ *        MACRO's for the specific device can be placed to expand the list.
+ */
+typedef enum {
+    GPIO_PORT_A,
+    GPIO_PORT_B
+} gpio_port_t;
 
+/**
+ * @brief The supported GPIO modes of the SAMD, GPIO_MODE A...N are PIN-MUX options,
+ *        The other two options are just for pin direction (INPUT or OUTPUT).
+ *        The default startup-option of the SAMD is input w/o pull (-up or -down) options
+ */
 typedef enum {
     GPIO_MODE_A,
     GPIO_MODE_B,
@@ -54,11 +71,24 @@ typedef enum {
     GPIO_MODE_OUTPUT,
 } gpio_mode_t;
 
+/**
+ * @brief A pin on the SAMD series consists of a PORT letter with a number, to imitate this as closely as possible a port_num and pin_num is used:
+ *        PA11 -> GPIO_PORT_A, 11
+ */
 typedef struct {
     gpio_port_t port_num;
-    uint8_t pin_num;
+    uint8_t     pin_num;
 } gpio_pin_t;
 
+/**
+ * @brief The SAMD series have some special options:
+ *        GPIO_OPT_PULL_UP: enables a internal pull-up on an input pin.
+ *        GPIO_OPT_PULL_DOWN: enables a internal pull-down on an input pin.
+ *        GPIO_OPT_SAMPLE_CONTINUOUSLY: enables continuously monitoring on input pins instead of on-demand (sips more energy)
+ *        GPIO_OPT_DRIVE_STRENGTH_STRONG: enables stronger drive current on the selected (output) pin (20mA instead of 2mA) (is enabled on startup)
+ * @note Not selecting a option in the set_gpio_pin_option() function disables the option prematurely.
+ * @note If you want multiple options OR them together like this: options = GPIO_OPT_PULL_UP | GPIO_OPT_SAMPLE_CONTINUOUSLY;
+ */
 typedef enum {
     GPIO_OPT_PULL_UP = 4,
     GPIO_OPT_PULL_DOWN = 8,
@@ -66,6 +96,11 @@ typedef enum {
     GPIO_OPT_DRIVE_STRENGTH_STRONG = 64,
 } gpio_opt_t;
 
+/**
+ * @brief The SAMD series use a specific IRQ peripheral for mapping IO pins to IRQ channels.
+ *        Look in the datasheet which pin in group A of the pin-mux belongs to which input channel.
+ *        Most of the times if the pin number is under 15 it maps directly to the IRQ channel number, except 8 which is probably NMI.
+ */
 typedef enum {
     GPIO_IRQ_CHANNEL_0,
     GPIO_IRQ_CHANNEL_1,
@@ -86,6 +121,9 @@ typedef enum {
     GPIO_IRQ_NMI
 } gpio_irq_channel_t;
 
+/**
+ * @brief The SAMD series support the following signal conditions on which a GPIO irq can be triggered.
+ */
 typedef enum {
     GPIO_IRQ_NONE,
     GPIO_IRQ_COND_RISING_EDGE,
@@ -95,19 +133,32 @@ typedef enum {
     GPIO_IRQ_COND_LOW_LVL
 } gpio_irq_condition_t;
 
-typedef enum{
+/**
+ * @brief These are extra options the SAMD series support besides the normal options:
+ *        GPIO_IRQ_EXTRA_NONE: Will disable all other special functions
+ *        GPIO_IRQ_EXTRA_FILTERING: Will enable extra filtering on the input pin
+ *        GPIO_IRQ_USE_EVENTS: Will use the event system instead of the EIC of the SAMD
+ *        GPIO_IRQ_WAKE_FROM_SLEEP: When set interrupts will wake the MCU up from sleep modes
+ */
+typedef enum {
     GPIO_IRQ_EXTRA_NONE,
     GPIO_IRQ_EXTRA_FILTERING,
     GPIO_IRQ_USE_EVENTS,
     GPIO_IRQ_WAKE_FROM_SLEEP
-}gpio_irq_extra_opt_t;
+} gpio_irq_extra_opt_t;
 
+/**
+ * @brief The options which need to be set to get gpio interrupts working on the SAMD series:
+ *        irq_channel: The channel which belongs to the input pin
+ *        irq_condition: The condition to trigger the IRQ on
+ *        irq_extra_opt: Extra options which the SAMD controller supports.
+ * @note For minimal functionality at least set the irq_channel and irq_condition options.
+ */
 typedef struct {
-gpio_irq_channel_t irq_channel;
-gpio_irq_condition_t irq_condition;
-gpio_irq_extra_opt_t irq_extra_opt;
+    gpio_irq_channel_t   irq_channel;
+    gpio_irq_condition_t irq_condition;
+    gpio_irq_extra_opt_t irq_extra_opt;
 } gpio_irq_opt_t;
-
 
 #ifdef __cplusplus
 }

--- a/hal/platform/atmelsam/gpio_platform_specific.h
+++ b/hal/platform/atmelsam/gpio_platform_specific.h
@@ -66,6 +66,49 @@ typedef enum {
     GPIO_OPT_DRIVE_STRENGTH_STRONG = 64,
 } gpio_opt_t;
 
+typedef enum {
+    GPIO_IRQ_CHANNEL_0,
+    GPIO_IRQ_CHANNEL_1,
+    GPIO_IRQ_CHANNEL_2,
+    GPIO_IRQ_CHANNEL_3,
+    GPIO_IRQ_CHANNEL_4,
+    GPIO_IRQ_CHANNEL_5,
+    GPIO_IRQ_CHANNEL_6,
+    GPIO_IRQ_CHANNEL_7,
+    GPIO_IRQ_CHANNEL_8,
+    GPIO_IRQ_CHANNEL_9,
+    GPIO_IRQ_CHANNEL_10,
+    GPIO_IRQ_CHANNEL_11,
+    GPIO_IRQ_CHANNEL_12,
+    GPIO_IRQ_CHANNEL_13,
+    GPIO_IRQ_CHANNEL_14,
+    GPIO_IRQ_CHANNEL_15,
+    GPIO_IRQ_NMI
+} gpio_irq_channel_t;
+
+typedef enum {
+    GPIO_IRQ_NONE,
+    GPIO_IRQ_COND_RISING_EDGE,
+    GPIO_IRQ_COND_FALLING_EDGE,
+    GPIO_IRQ_COND_BOTH_EDGES,
+    GPIO_IRQ_COND_HIGH_LVL,
+    GPIO_IRQ_COND_LOW_LVL
+} gpio_irq_condition_t;
+
+typedef enum{
+    GPIO_IRQ_EXTRA_NONE,
+    GPIO_IRQ_EXTRA_FILTERING,
+    GPIO_IRQ_USE_EVENTS,
+    GPIO_IRQ_WAKE_FROM_SLEEP
+}gpio_irq_extra_opt_t;
+
+typedef struct {
+gpio_irq_channel_t irq_channel;
+gpio_irq_condition_t irq_condition;
+gpio_irq_extra_opt_t irq_extra_opt;
+} gpio_irq_opt_t;
+
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/hal/platform/atmelsam/gpio_platform_specific.h
+++ b/hal/platform/atmelsam/gpio_platform_specific.h
@@ -24,63 +24,49 @@
 
 #ifndef GPIO_PLATFORM_SPECIFIC
 #define GPIO_PLATFORM_SPECIFIC
-
-#define HAS_NO_GPIO_PORT_DESIGNATORS 0
-#define SUPPORT_DRIVE_STRENGTH_SETTING 1
-#define SUPPORT_PINMUX 1
-#define SUPPORT_PIN_TOGGLE 1
-#define SUPPORT_PIN_SAMPLING_MODE_SELECT 1
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef enum {
-   kGPIOPortA,
-   kGPIOPortB,
-   kGPIOPortC
-} GPIOPort;
+    GPIO_LOW,
+    GPIO_HIGH,
+} gpio_level_t;
+
+typedef enum { GPIO_PORT_A, GPIO_PORT_B, GPIO_PORT_C } gpio_port_t;
 
 typedef enum {
-    kGPIONormalDriveStrength,
-    kGPIOStrongDriveStrength
-} GPIODriveStrength;
-
-typedef enum {
-  kGPIOFunctionA = 0x0,
-  kGPIOFunctionB = 0x1,
-  kGPIOFunctionC = 0x2,
-  kGPIOFunctionD = 0x3,
-  kGPIOFunctionE = 0x4,
-  kGPIOFunctionF = 0x5,
-  kGPIOFunctionG = 0x6,
-  kGPIOFunctionH = 0x7,
-  kGPIOFunctionI = 0x8,
-  kGPIOFunctionJ = 0x9,
-  kGPIOFunctionK = 0xA,
-  kGPIOFunctionL = 0xB,
-  kGPIOFunctionM = 0xC,
-  kGPIOFunctionN = 0xD
-} GPIOPinFunction;
-
-typedef enum {
-  kGPIOPullDown,
-  kGPIOPullUp,
-  kGPIONoPull
-} GPIOPull;
-
-typedef enum {
-  kGPIOSampleOnDemand,
-  kGPIOSampleContinuously
-} GPIOSamplingMode;
-
-typedef enum {
-  kGPIOEventOut,
-  kGPIOEventSet,
-  kGPIOEventClr,
-  kGPIOEventTgl
-} GPIOInputEvent;
-
+    GPIO_MODE_A,
+    GPIO_MODE_B,
+    GPIO_MODE_C,
+    GPIO_MODE_D,
+    GPIO_MODE_E,
+    GPIO_MODE_F,
+    GPIO_MODE_G,
+    GPIO_MODE_H,
+    GPIO_MODE_I,
+    GPIO_MODE_J,
+    GPIO_MODE_K,
+    GPIO_MODE_L,
+    GPIO_MODE_N,
+    GPIO_MODE_INPUT,
+    GPIO_MODE_OUTPUT,
+} gpio_mode_t;
 
 typedef struct {
-  GPIOPort port_num;
-  unsigned char pin_num;
-} GPIOPin;
+    gpio_port_t port_num;
+    uint8_t pin_num;
+} gpio_pin_t;
 
+typedef enum {
+    GPIO_OPT_PULL_UP = 4,
+    GPIO_OPT_PULL_DOWN = 8,
+    GPIO_OPT_SAMPLE_CONTINUOUSLY = 32,
+    GPIO_OPT_DRIVE_STRENGTH_STRONG = 64,
+} gpio_opt_t;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -1,19 +1,26 @@
+/**
+* \file            gpio_samd.c
+* \brief           Source file which implements the standard GPIO API functions
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 #include <../../hal_gpio.h>
 #include "gpio_platform_specific.h"
 #include <sam.h>

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -22,6 +22,7 @@
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
 #include <sam.h>
+#include "bit_manipulation.h"
 #include "gpio_platform_specific.h"
 #include "hal_gpio.h"
 
@@ -29,32 +30,52 @@
 #define GPIO_OPT_PULL_DOWN_POS           3
 #define GPIO_OPT_SAMPLE_CONTINUOUSLY_POS 5
 
-#define VALUE_CONTAINS_MASK(NUM, MASK) (NUM & MASK)
-#define BIT_IS_SET(VAL, BIT_NUM) (VAL >> BIT_NUM) & 1
-#define SHIFT_N(N) 1 << N
-
-#define PIN_IS_EVEN_NUMBER(x) (x % 2) == 0
-
 void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level) {
     if (level) {
-        PORT->Group[pin.port_num].OUTSET.reg = SHIFT_N(pin.pin_num);
+        /*
+         * GPIO LEVEL HIGH: Set the OUTSET register to (1 << pin_num).
+         * This will set a high output state if pin is set to output direction
+         * or manually enable pull-ups if the pin is set to output and PULLEN bit is set.
+         */
+        PORT->Group[pin.port_num].OUTSET.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     } else {
-        PORT->Group[pin.port_num].OUTCLR.reg = SHIFT_N(pin.pin_num);
+        /* GPIO LEVEL LOW: Set the OUTCLR register to (1 << pin_num).
+         * This will set a low output state if pin is set to output direction.
+         */
+        PORT->Group[pin.port_num].OUTCLR.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     }
 }
 
 void toggle_gpio_pin_output(const gpio_pin_t pin) {
-    PORT->Group[pin.port_num].OUTTGL.reg = SHIFT_N(pin.pin_num);
+    /*
+     * The OUTTGL register gets set with a value of (1 << pin_num).
+     * This will toggle the output status of the given pin.
+     * @note This will cause unwanted behaviour if pin is set as input instead of output.
+     */
+    PORT->Group[pin.port_num].OUTTGL.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
 }
 
 gpio_level_t get_gpio_pin_level(const gpio_pin_t pin) {
+    /*
+     * The IN register will be read and the bit corresponding to the pin number get returned.
+     * This gives the current input status of the pin.
+     */
     const gpio_level_t res = BIT_IS_SET(PORT->Group[pin.port_num].IN.reg, pin.pin_num);
     return res;
 }
 
 static inline void prv_set_function(const gpio_pin_t pin, const uint8_t function) {
-    PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0x01; /* Enable the pin mux function */
-    /* There is a separate pin mux for even and odd pins (See datasheet) */
+    /* Enable the internal pin-mux function */
+    PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0x01;
+    //    PORT->Group[pin.pin_num].OUTCLR.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
+    /* There is a separate pin-mux for even and odd pins (See datasheet)
+     * Pin.pin.num has to be shifted to the right by two to divide in two,
+     * Then the corresponding even or oneven register can be written.
+     *
+     * Writing to the PMUXE or PMUXO register sets the function corresponding to
+     * the PORT FUNCTION MULTIPLEXING table 7-1. This value goes from group A..H
+     * and is mapped to numbers using the function enum.
+     */
     if (PIN_IS_EVEN_NUMBER(pin.pin_num)) {
         PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXE = function;
     } else {
@@ -66,14 +87,17 @@ static inline void prv_set_dir(const gpio_pin_t pin, const uint8_t direction) {
     PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0;
     if (direction == GPIO_MODE_OUTPUT) {
         PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg &= ~(PORT_PINCFG_INEN);
-        PORT->Group[pin.port_num].DIRSET.reg = SHIFT_N(pin.pin_num);
+        PORT->Group[pin.port_num].DIRSET.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     } else {
         PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = PORT_PINCFG_INEN;
-        PORT->Group[pin.port_num].DIRCLR.reg = SHIFT_N(pin.pin_num);
+        PORT->Group[pin.port_num].DIRCLR.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     }
 }
 
 void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode) {
+    /*
+     * Detect using the offset of GPIO_MODE_INPUT in the enum whether the mode is an input or output
+     */
     const uint8_t pin_mode_is_direction = (pin_mode >= GPIO_MODE_INPUT);
     if (pin_mode_is_direction) {
         prv_set_dir(pin, pin_mode);
@@ -82,62 +106,188 @@ void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode) {
     }
 }
 
-gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin) {
-    const uint8_t pincfg_reg = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
-    if (pincfg_reg & PORT_PINCFG_PMUXEN) {
-        const uint8_t pmux_reg = PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].reg;
-        if (PIN_IS_EVEN_NUMBER(pin.pin_num)) {
-            const uint8_t res = VALUE_CONTAINS_MASK(pmux_reg, 0xF);
-            return res;
-        } else {
-            const uint8_t res = VALUE_CONTAINS_MASK((pmux_reg >> 4), 0xF);
-            return res;
-        }
+static inline gpio_mode_t prv_get_function(const gpio_pin_t pin) {
+    const uint8_t pmux_reg = PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].reg;
+    if (PIN_IS_EVEN_NUMBER(pin.pin_num)) {
+        const uint8_t res = GET_LOWER_4_BITS_OF_BYTE(pmux_reg);
+        return res;
     } else {
-        const uint32_t pin_is_set_as_output_pin = PORT->Group[pin.port_num].DIR.reg & (1 << pin.pin_num);
-        if (pin_is_set_as_output_pin) {
-            return GPIO_MODE_OUTPUT;
-        } else {
-            return GPIO_MODE_INPUT;
-        }
+        const uint8_t res = GET_UPPER_4_BITS_OF_BYTE(pmux_reg);
+        return res;
     }
 }
 
-void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
+static inline gpio_mode_t prv_get_dir(const gpio_pin_t pin) {
+    const uint32_t pin_is_set_as_output_pin = BITMASK_COMPARE(PORT->Group[pin.port_num].DIR.reg, SHIFT_ONE_LEFT_BY_N(pin.pin_num));
+    if (pin_is_set_as_output_pin) {
+        return GPIO_MODE_OUTPUT;
+    } else {
+        return GPIO_MODE_INPUT;
+    }
+}
+
+gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin) {
+    const uint8_t pincfg_reg = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    if (pincfg_reg & PORT_PINCFG_PMUXEN) {
+        return prv_get_function(pin);
+    } else {
+        return prv_get_dir(pin);
+    }
+}
+
+static inline uint8_t get_non_settable_pincfg_options(const gpio_pin_t pin) {
     const uint8_t prev_pincfg_val = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
-    const uint8_t non_settable_opt = (VALUE_CONTAINS_MASK(prev_pincfg_val, PORT_PINCFG_PMUXEN) | VALUE_CONTAINS_MASK(prev_pincfg_val, PORT_PINCFG_INEN));
-    const uint8_t pull_up_en = VALUE_CONTAINS_MASK(opt, GPIO_OPT_PULL_UP);
-    const uint8_t pull_en = ((VALUE_CONTAINS_MASK(opt, GPIO_OPT_PULL_DOWN) >> 1) |(pull_up_en));
-    const uint8_t sampling_opt_set = VALUE_CONTAINS_MASK(opt, GPIO_OPT_SAMPLE_CONTINUOUSLY);
-    const uint8_t reg_val = non_settable_opt | pull_en | VALUE_CONTAINS_MASK(opt, GPIO_OPT_DRIVE_STRENGTH_STRONG);
+    const uint8_t non_settable_opt = (BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_PMUXEN) | BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_INEN));
+    return non_settable_opt;
+}
+
+void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
+    /*
+     * Some bits in the pincfg register are not set by this function and should not be changed.
+     * These bits are retrieved with this function to be included in the final reg_val later.
+     */
+    const uint8_t non_settable_pincfg_options = get_non_settable_pincfg_options(pin);
+    /*
+     * Do some trickery. The enum with gpio options has PULL_DOWN and PULL_UP defined.
+     * The pull-up register and drive_strength bit positions are aligned with the position
+     * in the pincfg register. Thus minimal operations are needed to translate flags to setting bits.
+     *
+     * The PULL_DOWN option differs one bit position from the PULL_UP option, and PULL_UP is aligned with PULL_EN flag.
+     * To enable PULL_EN flag we need to just shift one bit to enable the PULL_EN flag :)
+     */
+    const uint8_t pull_up_en = BITMASK_COMPARE(opt, GPIO_OPT_PULL_UP);
+    const uint8_t pull_en = ((BITMASK_COMPARE(opt, GPIO_OPT_PULL_DOWN) >> 1) | (pull_up_en));
+    const uint8_t reg_val = non_settable_pincfg_options | pull_en | BITMASK_COMPARE(opt, GPIO_OPT_DRIVE_STRENGTH_STRONG);
     PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = reg_val;
 
+    /*
+     * When the pull-up option is set we need to do one extra operation.
+     * Set the OUTSET register, to disable the default pull_down and enable pull_up.
+     */
     if (pull_up_en && pull_en) {
-        PORT->Group[pin.port_num].OUTSET.reg = SHIFT_N(pin.pin_num);
+        PORT->Group[pin.port_num].OUTSET.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     }
 
-    uint32_t res = PORT->Group[pin.port_num].CTRL.reg;
+    /*
+     * The sampling options are not set in the pincfg and require to be written to
+     * the CTRL register. That is what this section does.
+     */
+    const uint8_t sampling_opt_set = BITMASK_COMPARE(opt, GPIO_OPT_SAMPLE_CONTINUOUSLY);
+    uint32_t      res = PORT->Group[pin.port_num].CTRL.reg;
     if (sampling_opt_set) {
-        res |= SHIFT_N(pin.pin_num);
+        res |= SHIFT_ONE_LEFT_BY_N(pin.pin_num);
         PORT->Group[pin.port_num].CTRL.reg = res;
     } else {
-        res &= ~(SHIFT_N(pin.pin_num));
+        res &= ~(SHIFT_ONE_LEFT_BY_N(pin.pin_num));
         PORT->Group[pin.port_num].CTRL.reg = res;
     }
 }
 
 gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
+    /*
+     * Get the pincfg register to extract the PULL_EN and DRIVE_STR bits from.
+     */
     const uint8_t pincfg_register = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
-    const uint8_t pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
-    const uint8_t pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS;
+
     const uint8_t sampling_opt_en = BIT_IS_SET(PORT->Group[pin.port_num].CTRL.reg, pin.pin_num);
 
-    uint8_t res = VALUE_CONTAINS_MASK(pincfg_register, GPIO_OPT_DRIVE_STRENGTH_STRONG) | (sampling_opt_en << GPIO_OPT_SAMPLE_CONTINUOUSLY_POS);
+    uint8_t res = BITMASK_COMPARE(pincfg_register, GPIO_OPT_DRIVE_STRENGTH_STRONG) | (sampling_opt_en << GPIO_OPT_SAMPLE_CONTINUOUSLY_POS);
 
-    if (VALUE_CONTAINS_MASK(pincfg_register, PORT_PINCFG_PULLEN)) {
-        res |= (pull_down_en) | (pull_up_en << GPIO_OPT_PULL_UP_POS);
+    if (BITMASK_COMPARE(pincfg_register, PORT_PINCFG_PULLEN)) {
+        /*
+         * Pull-up requires out register to be set.. This will be used to distinguish whether a pull-up or pull-down is set.
+         */
+        const uint8_t pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
+        const uint8_t pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS; /* PULL_UP is not set, then it must be a PULL_DOWN */
+        res |= (pull_down_en) | (pull_up_en << GPIO_OPT_PULL_UP_POS);             /* Add flags to end result */
         return res;
     }
 
     return res;
+}
+
+void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
+    /*
+     * Check whether pin given is set as output or input. If set as output make it an input.
+     */
+    const uint32_t pin_is_set_as_output = BITMASK_COMPARE(PORT->Group[pin.port_num].DIR.reg, SHIFT_ONE_LEFT_BY_N(pin.pin_num));
+    if (pin_is_set_as_output) {
+        prv_set_dir(pin, GPIO_MODE_INPUT);
+    }
+
+    /*
+     * Set the pin-mux to GPIO_MODE_A which is the EIC group on most of SAMD microcontroller lines
+     */
+    prv_set_function(pin, GPIO_MODE_A);
+
+    /*
+     * Set the clock of EIC to the system_clk on CLK_GEN_0,
+     * which is the most used clock generator for system clocks among frameworks.
+     */
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_ID_EIC | GCLK_CLKCTRL_GEN_GCLK0;
+
+    /*
+     * Wait for the peripheral to apply changes..
+     * @todo add a timeout function with error return status if fails
+     */
+    while (GCLK->STATUS.bit.SYNCBUSY) {}
+
+    /*
+     * EIC is divided within two sections: GPIO_CONFIG0 AND GPIO_CONFIG1 because the system is limited to 32-bit register sizes.
+     * Therefore we need to decide on basis of the channel selected which CONFIG register to write.
+     */
+    if (irq_opt.irq_channel <= GPIO_IRQ_CHANNEL_7) {
+        /*
+         * Calculate the bit_positions of the filter_mask and trigger_mask bits for the specific pin-channel
+         * and convert it in to a mask.
+         */
+        const uint32_t filter_mask = BITMASK_COMPARE(irq_opt.irq_extra_opt, GPIO_IRQ_EXTRA_FILTERING)
+                                     << ((irq_opt.irq_channel * 4) + (EIC_CONFIG_FILTEN0_Pos));
+        const uint32_t trigger_mask = irq_opt.irq_condition << (4 * irq_opt.irq_channel);
+        EIC->CONFIG[0].reg |= filter_mask | trigger_mask;
+    } else if (irq_opt.irq_channel <= GPIO_IRQ_CHANNEL_15) {
+        const uint32_t filter_mask = BITMASK_COMPARE(irq_opt.irq_extra_opt, GPIO_IRQ_EXTRA_FILTERING)
+                                     << (((irq_opt.irq_channel - GPIO_IRQ_CHANNEL_8) * 4) + (EIC_CONFIG_FILTEN0_Pos));
+        const uint32_t trigger_mask = irq_opt.irq_condition << (4 * (irq_opt.irq_channel - GPIO_IRQ_CHANNEL_8));
+        EIC->CONFIG[1].reg |= filter_mask | trigger_mask;
+    } else {
+        const uint32_t filter_mask = BITMASK_COMPARE(irq_opt.irq_extra_opt, GPIO_IRQ_EXTRA_FILTERING) << EIC_NMICTRL_NMIFILTEN_Pos;
+        const uint32_t trigger_mask = irq_opt.irq_condition;
+        EIC->NMICTRL.reg = filter_mask | trigger_mask;
+    }
+
+    if (BITMASK_COMPARE(irq_opt.irq_extra_opt, GPIO_IRQ_WAKE_FROM_SLEEP)) {
+        EIC->WAKEUP.reg |= SHIFT_ONE_LEFT_BY_N(irq_opt.irq_channel);
+    } else {
+        EIC->WAKEUP.reg &= ~(SHIFT_ONE_LEFT_BY_N(irq_opt.irq_channel));
+    }
+    /*
+     * Check whether to use interrupts or events,
+     * if events configure as little as possible to make it working :)
+     */
+    if (BITMASK_COMPARE(irq_opt.irq_extra_opt, GPIO_IRQ_USE_EVENTS)) {
+        EIC->INTENCLR.reg = SHIFT_ONE_LEFT_BY_N(irq_opt.irq_channel);
+        EIC->EVCTRL.reg |= SHIFT_ONE_LEFT_BY_N(irq_opt.irq_channel);
+    } else {
+        NVIC_DisableIRQ(EIC_IRQn);
+        NVIC_ClearPendingIRQ(EIC_IRQn);
+
+        NVIC_SetPriority(EIC_IRQn, 0);
+        NVIC_EnableIRQ(EIC_IRQn);
+
+        /*
+         * Set the interrupt for this specific pin.
+         */
+        EIC->INTENSET.reg = SHIFT_ONE_LEFT_BY_N(irq_opt.irq_channel);
+    }
+    /*
+     * Enable the peripheral
+     */
+    EIC->CTRL.reg |= EIC_CTRL_ENABLE;
+
+    /*
+     * Wait for the peripheral to apply changes..
+     * @todo add a timeout function with error return status if fails
+     */
+    while (EIC->STATUS.bit.SYNCBUSY) {}
 }

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -107,8 +107,8 @@ void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode) {
 }
 
 static inline gpio_mode_t prv_get_function(const gpio_pin_t pin) {
-    uint8_t pmux_reg, res;
-    pmux_reg = PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].reg;
+    const uint8_t pmux_reg = PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].reg;
+    uint8_t res;
     if (PIN_IS_EVEN_NUMBER(pin.pin_num)) {
         res = GET_LOWER_4_BITS_OF_BYTE(pmux_reg);
         return res;
@@ -137,20 +137,17 @@ gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin) {
 }
 
 static inline uint8_t get_non_settable_pincfg_options(const gpio_pin_t pin) {
-    uint8_t prev_pincfg_val, non_settable_opt;
-    prev_pincfg_val = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
-    non_settable_opt = (BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_PMUXEN) | BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_INEN));
+    const uint8_t prev_pincfg_val = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    const uint8_t non_settable_opt = (BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_PMUXEN) | BITMASK_COMPARE(prev_pincfg_val, PORT_PINCFG_INEN));
     return non_settable_opt;
 }
 
 void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
-    uint32_t res;
-    uint8_t  non_settable_pincfg_options, pull_up_en, pull_en, reg_val, sampling_opt_set;
     /*
      * Some bits in the pincfg register are not set by this function and should not be changed.
      * These bits are retrieved with this function to be included in the final reg_val later.
      */
-    non_settable_pincfg_options = get_non_settable_pincfg_options(pin);
+    const uint8_t non_settable_pincfg_options = get_non_settable_pincfg_options(pin);
     /*
      * Do some trickery. The enum with gpio options has PULL_DOWN and PULL_UP defined.
      * The pull-up register and drive_strength bit positions are aligned with the position
@@ -159,9 +156,9 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
      * The PULL_DOWN option differs one-bit position from the PULL_UP option, and PULL_UP is aligned with the PULL_EN flag.
      * To enable the PULL_EN flag, we need to just shift one bit to enable the PULL_EN flag :)
      */
-    pull_up_en = BITMASK_COMPARE(opt, GPIO_OPT_PULL_UP);
-    pull_en = ((BITMASK_COMPARE(opt, GPIO_OPT_PULL_DOWN) >> 1) | (pull_up_en));
-    reg_val = non_settable_pincfg_options | pull_en | BITMASK_COMPARE(opt, GPIO_OPT_DRIVE_STRENGTH_STRONG);
+    const uint8_t pull_up_en = BITMASK_COMPARE(opt, GPIO_OPT_PULL_UP);
+    const uint8_t pull_en = ((BITMASK_COMPARE(opt, GPIO_OPT_PULL_DOWN) >> 1) | (pull_up_en));
+    const uint8_t reg_val = non_settable_pincfg_options | pull_en | BITMASK_COMPARE(opt, GPIO_OPT_DRIVE_STRENGTH_STRONG);
     PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = reg_val;
 
     /*
@@ -176,8 +173,8 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
      * The sampling options are not set in the pincfg and require to be written to
      * the CTRL register. That is what this section does.
      */
-    sampling_opt_set = BITMASK_COMPARE(opt, GPIO_OPT_SAMPLE_CONTINUOUSLY);
-    res = PORT->Group[pin.port_num].CTRL.reg;
+    const uint8_t sampling_opt_set = BITMASK_COMPARE(opt, GPIO_OPT_SAMPLE_CONTINUOUSLY);
+    uint32_t res = PORT->Group[pin.port_num].CTRL.reg;
     if (sampling_opt_set) {
         res |= SHIFT_ONE_LEFT_BY_N(pin.pin_num);
         PORT->Group[pin.port_num].CTRL.reg = res;
@@ -188,22 +185,21 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
 }
 
 gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
-    uint8_t pincfg_register, sampling_opt_en, res, pull_up_en, pull_down_en;
     /*
      * Get the pincfg register to extract the PULL_EN and DRIVE_STR bits from.
      */
-    pincfg_register = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    const uint8_t pincfg_register = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
 
-    sampling_opt_en = BIT_IS_SET(PORT->Group[pin.port_num].CTRL.reg, pin.pin_num);
+    const uint8_t sampling_opt_en = BIT_IS_SET(PORT->Group[pin.port_num].CTRL.reg, pin.pin_num);
 
-    res = BITMASK_COMPARE(pincfg_register, GPIO_OPT_DRIVE_STRENGTH_STRONG) | (sampling_opt_en << GPIO_OPT_SAMPLE_CONTINUOUSLY_POS);
+    uint8_t res = BITMASK_COMPARE(pincfg_register, GPIO_OPT_DRIVE_STRENGTH_STRONG) | (sampling_opt_en << GPIO_OPT_SAMPLE_CONTINUOUSLY_POS);
 
     if (BITMASK_COMPARE(pincfg_register, PORT_PINCFG_PULLEN)) {
         /*
          * Pull-up requires out register to be set... This will be used to distinguish whether a pull-up or pull-down is set.
          */
-        pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
-        pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS; /* PULL_UP is not set, then it must be a PULL_DOWN */
+        const uint8_t pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
+        const uint8_t pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS; /* PULL_UP is not set, then it must be a PULL_DOWN */
         res |= (pull_down_en) | (pull_up_en << GPIO_OPT_PULL_UP_POS);             /* Add flags to the end result */
         return res;
     }
@@ -212,11 +208,10 @@ gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
 }
 
 void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
-    uint32_t pin_is_set_as_output, filter_mask, trigger_mask;
     /*
      * Check whether pin given is set as output or input. If set as output, make it an input.
      */
-    pin_is_set_as_output = BITMASK_COMPARE(PORT->Group[pin.port_num].DIR.reg, SHIFT_ONE_LEFT_BY_N(pin.pin_num));
+    const uint32_t pin_is_set_as_output = BITMASK_COMPARE(PORT->Group[pin.port_num].DIR.reg, SHIFT_ONE_LEFT_BY_N(pin.pin_num));
     if (pin_is_set_as_output) {
         prv_set_dir(pin, GPIO_MODE_INPUT);
     }
@@ -242,6 +237,7 @@ void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
      * EIC is divided within two sections: GPIO_CONFIG0 AND GPIO_CONFIG1 because the system is limited to 32-bit register sizes.
      * Therefore, we need to decide on the basis of the channel selected which CONFIG register to write.
      */
+    uint32_t filter_mask, trigger_mask;
     if (irq_opt.irq_channel <= GPIO_IRQ_CHANNEL_7) {
         /*
          * Calculate the bit_positions of the filter_mask and trigger_mask bits for the specific pin-channel

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -57,7 +57,7 @@ void toggle_gpio_pin_output(const gpio_pin_t pin) {
 
 gpio_level_t get_gpio_pin_level(const gpio_pin_t pin) {
     /*
-     * The IN register will be read and the bit corresponding to the pin number get returned.
+     * The IN register will be read and the bit corresponding to the pin get returned.
      * This gives the current input status of the pin.
      */
     const gpio_level_t res = BIT_IS_SET(PORT->Group[pin.port_num].IN.reg, pin.pin_num);
@@ -70,10 +70,10 @@ static inline void prv_set_function(const gpio_pin_t pin, const uint8_t function
     //    PORT->Group[pin.pin_num].OUTCLR.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     /* There is a separate pin-mux for even and odd pins (See datasheet)
      * Pin.pin.num has to be shifted to the right by two to divide in two,
-     * Then the corresponding even or oneven register can be written.
+     * Then the corresponding even or uneven register can be written.
      *
      * Writing to the PMUXE or PMUXO register sets the function corresponding to
-     * the PORT FUNCTION MULTIPLEXING table 7-1. This value goes from group A..H
+     * the PORT FUNCTION MULTIPLEXING table 7-1. This value goes from group A...H
      * and is mapped to numbers using the function enum.
      */
     if (PIN_IS_EVEN_NUMBER(pin.pin_num)) {
@@ -150,7 +150,7 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
     /*
      * Do some trickery. The enum with gpio options has PULL_DOWN and PULL_UP defined.
      * The pull-up register and drive_strength bit positions are aligned with the position
-     * in the pincfg register. Thus minimal operations are needed to translate flags to setting bits.
+     * in the pincfg register. Thus, minimal operations are needed to translate flags to setting bits.
      *
      * The PULL_DOWN option differs one bit position from the PULL_UP option, and PULL_UP is aligned with PULL_EN flag.
      * To enable PULL_EN flag we need to just shift one bit to enable the PULL_EN flag :)
@@ -195,7 +195,7 @@ gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
 
     if (BITMASK_COMPARE(pincfg_register, PORT_PINCFG_PULLEN)) {
         /*
-         * Pull-up requires out register to be set.. This will be used to distinguish whether a pull-up or pull-down is set.
+         * Pull-up requires out register to be set... This will be used to distinguish whether a pull-up or pull-down is set.
          */
         const uint8_t pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
         const uint8_t pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS; /* PULL_UP is not set, then it must be a PULL_DOWN */
@@ -234,7 +234,7 @@ void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
 
     /*
      * EIC is divided within two sections: GPIO_CONFIG0 AND GPIO_CONFIG1 because the system is limited to 32-bit register sizes.
-     * Therefore we need to decide on basis of the channel selected which CONFIG register to write.
+     * Therefore, we need to decide on basis of the channel selected which CONFIG register to write.
      */
     if (irq_opt.irq_channel <= GPIO_IRQ_CHANNEL_7) {
         /*

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -34,13 +34,13 @@ void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level) {
     if (level) {
         /*
          * GPIO LEVEL HIGH: Set the OUTSET register to (1 << pin_num).
-         * This will set a high output state if pin is set to output direction
+         * This will set a high output state if a pin is set to the output direction
          * or manually enable pull-ups if the pin is set to output and PULLEN bit is set.
          */
         PORT->Group[pin.port_num].OUTSET.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     } else {
         /* GPIO LEVEL LOW: Set the OUTCLR register to (1 << pin_num).
-         * This will set a low output state if pin is set to output direction.
+         * This will set a low output state if pin is set to the output direction.
          */
         PORT->Group[pin.port_num].OUTCLR.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
     }
@@ -50,14 +50,14 @@ void toggle_gpio_pin_output(const gpio_pin_t pin) {
     /*
      * The OUTTGL register gets set with a value of (1 << pin_num).
      * This will toggle the output status of the given pin.
-     * @note This will cause unwanted behaviour if pin is set as input instead of output.
+     * @note This will cause unwanted behavior if a pin is set as input instead of output.
      */
     PORT->Group[pin.port_num].OUTTGL.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
 }
 
 gpio_level_t get_gpio_pin_level(const gpio_pin_t pin) {
     /*
-     * The IN register will be read and the bit corresponding to the pin get returned.
+     * The IN register will be read, and the bit corresponding to the pin gets returned.
      * This gives the current input status of the pin.
      */
     const gpio_level_t res = BIT_IS_SET(PORT->Group[pin.port_num].IN.reg, pin.pin_num);
@@ -152,8 +152,8 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
      * The pull-up register and drive_strength bit positions are aligned with the position
      * in the pincfg register. Thus, minimal operations are needed to translate flags to setting bits.
      *
-     * The PULL_DOWN option differs one bit position from the PULL_UP option, and PULL_UP is aligned with PULL_EN flag.
-     * To enable PULL_EN flag we need to just shift one bit to enable the PULL_EN flag :)
+     * The PULL_DOWN option differs one-bit position from the PULL_UP option, and PULL_UP is aligned with the PULL_EN flag.
+     * To enable the PULL_EN flag, we need to just shift one bit to enable the PULL_EN flag :)
      */
     const uint8_t pull_up_en = BITMASK_COMPARE(opt, GPIO_OPT_PULL_UP);
     const uint8_t pull_en = ((BITMASK_COMPARE(opt, GPIO_OPT_PULL_DOWN) >> 1) | (pull_up_en));
@@ -161,8 +161,8 @@ void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
     PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = reg_val;
 
     /*
-     * When the pull-up option is set we need to do one extra operation.
-     * Set the OUTSET register, to disable the default pull_down and enable pull_up.
+     * When the pull-up option is set, we need to do one extra operation.
+     * Set the OUTSET register to disable the default pull_down and enable pull_up.
      */
     if (pull_up_en && pull_en) {
         PORT->Group[pin.port_num].OUTSET.reg = SHIFT_ONE_LEFT_BY_N(pin.pin_num);
@@ -199,7 +199,7 @@ gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
          */
         const uint8_t pull_up_en = BIT_IS_SET(PORT->Group[pin.port_num].OUT.reg, pin.pin_num);
         const uint8_t pull_down_en = (pull_up_en == 0) << GPIO_OPT_PULL_DOWN_POS; /* PULL_UP is not set, then it must be a PULL_DOWN */
-        res |= (pull_down_en) | (pull_up_en << GPIO_OPT_PULL_UP_POS);             /* Add flags to end result */
+        res |= (pull_down_en) | (pull_up_en << GPIO_OPT_PULL_UP_POS);             /* Add flags to the end result */
         return res;
     }
 
@@ -208,7 +208,7 @@ gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
 
 void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
     /*
-     * Check whether pin given is set as output or input. If set as output make it an input.
+     * Check whether pin given is set as output or input. If set as output, make it an input.
      */
     const uint32_t pin_is_set_as_output = BITMASK_COMPARE(PORT->Group[pin.port_num].DIR.reg, SHIFT_ONE_LEFT_BY_N(pin.pin_num));
     if (pin_is_set_as_output) {
@@ -216,7 +216,7 @@ void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
     }
 
     /*
-     * Set the pin-mux to GPIO_MODE_A which is the EIC group on most of SAMD microcontroller lines
+     * Set the pin-mux to GPIO_MODE_A which is the EIC group on most of the SAMD microcontroller lines
      */
     prv_set_function(pin, GPIO_MODE_A);
 
@@ -234,7 +234,7 @@ void set_gpio_interrupt(const gpio_pin_t pin, gpio_irq_opt_t irq_opt) {
 
     /*
      * EIC is divided within two sections: GPIO_CONFIG0 AND GPIO_CONFIG1 because the system is limited to 32-bit register sizes.
-     * Therefore, we need to decide on basis of the channel selected which CONFIG register to write.
+     * Therefore, we need to decide on the basis of the channel selected which CONFIG register to write.
      */
     if (irq_opt.irq_channel <= GPIO_IRQ_CHANNEL_7) {
         /*

--- a/hal/platform/atmelsam/gpio_samd.c
+++ b/hal/platform/atmelsam/gpio_samd.c
@@ -21,71 +21,109 @@
 *
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
-#include <../../hal_gpio.h>
-#include "gpio_platform_specific.h"
 #include <sam.h>
+#include <stdbool.h>
+#include "gpio_platform_specific.h"
+#include "hal_gpio.h"
 
-void SetGPIOPinLevel(const GPIOPin pin, const unsigned char level) {
-  if (level) {
-    PORT->Group[pin.port_num].OUTSET.reg |= 1 << pin.pin_num;
-  } else {
-    PORT->Group[pin.port_num].OUTCLR.reg |= 1 << pin.pin_num;
-  }
+#define GPIO_OPT_PULL_UP_POS             2
+#define GPIO_OPT_PULL_DOWN_POS           3
+#define GPIO_OPT_SAMPLE_CONTINUOUSLY_POS 5
+
+void set_gpio_pin_lvl(const gpio_pin_t pin, gpio_level_t level) {
+    if (level) {
+        PORT->Group[pin.port_num].OUTSET.reg = (1 << pin.pin_num);
+    } else {
+        PORT->Group[pin.port_num].OUTCLR.reg = (1 << pin.pin_num);
+    }
 }
 
-void ToggleGPIOPin(const GPIOPin pin) {
-  PORT->Group[pin.port_num].OUTTGL.reg |= 1 << pin.pin_num;
+void toggle_gpio_pin_output(const gpio_pin_t pin) {
+    PORT->Group[pin.port_num].OUTTGL.reg = 1 << pin.pin_num;
 }
 
-void SetGPIOPinDirection(const GPIOPin pin, const unsigned char direction) {
-  if (direction) {
-    PORT->Group[pin.port_num].DIRSET.reg |= 1 << pin.pin_num;
-  } else {
-    PORT->Group[pin.port_num].DIRCLR.reg |= 1 << pin.pin_num;
-  }
+const gpio_level_t get_gpio_pin_level(const gpio_pin_t pin) {
+    return (PORT->Group[pin.port_num].IN.reg >> pin.pin_num) & 1;
 }
 
-void SetGPIOPinDriveStrength(const GPIOPin pin, GPIODriveStrength driver_strength) {
-  if (driver_strength <= 1 && driver_strength > -1) {
-    PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.DRVSTR = driver_strength;
-  }
+void set_gpio_pin_mode(const gpio_pin_t pin, gpio_mode_t pin_mode) {
+    const uint8_t pin_mode_is_direction = (pin_mode >= GPIO_MODE_INPUT);
+    if (pin_mode_is_direction) {
+        PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0;
+        if (pin_mode == GPIO_MODE_OUTPUT) {
+            PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg &= ~(PORT_PINCFG_INEN);
+            PORT->Group[pin.port_num].DIRSET.reg = 1 << pin.pin_num;
+        } else {
+            PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = PORT_PINCFG_INEN;
+            PORT->Group[pin.port_num].DIRCLR.reg = 1 << pin.pin_num;
+        }
+    } else {
+        PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0x01; /* Enable the pin mux function */
+        /* There is a seperate pin mux for even and odd pin numbers (See datasheet) */
+        if (pin.pin_num % 2 == 0) {
+            PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXE = pin_mode;
+        } else {
+            PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXO = pin_mode;
+        }
+    }
 }
 
-void SetGPIOPinFunction(const GPIOPin pin, GPIOPinFunction pin_function) {
-  PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.PMUXEN = 0x01;  // Enable the pin mux function
-  // There is a seperate pin mux for even and odd pin numbers (See datasheet)
-  if (pin.pin_num % 2 == 0) {
-    PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXE |= pin_function;
-  } else {
-    PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXO |= pin_function;
-  }
+const gpio_mode_t get_gpio_pin_mode(const gpio_pin_t pin) {
+    const uint8_t pincfg_reg = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    if (pincfg_reg & PORT_PINCFG_PMUXEN) {
+        const uint8_t PMUX_RESULT = PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].reg;
+        if (pin.pin_num % 2) {
+            const uint8_t res = PMUX_RESULT & 0xF;
+            return res;
+        } else {
+            const uint8_t res = (PMUX_RESULT >> 4) & 0xF;
+            return res;
+        }
+    } else {
+        const uint32_t pin_is_set_as_output_pin = PORT->Group[pin.port_num].DIR.reg;
+        if (pin_is_set_as_output_pin) {
+            return GPIO_MODE_OUTPUT;
+        } else {
+            return GPIO_MODE_INPUT;
+        }
+    }
 }
 
-void SetGPIOPinSamplingMode(const GPIOPin pin, GPIOSamplingMode sampling_mode) {
-  if (sampling_mode == kGPIOSampleContinuously) {
-    PORT->Group[pin.port_num].CTRL.reg |= 1 << pin.pin_num;
-  } else {
-    PORT->Group[pin.port_num].CTRL.reg &= ~(1 << pin.pin_num);
-  }
+void set_gpio_pin_options(const gpio_pin_t pin, const gpio_opt_t opt) {
+    const uint8_t prev_pincfg_val = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    const uint8_t non_settable_opt = ((prev_pincfg_val & PORT_PINCFG_PMUXEN) | (prev_pincfg_val & PORT_PINCFG_INEN));
+    const uint8_t pullup = (opt & GPIO_OPT_PULL_UP);
+    const uint8_t pullen = ((opt & GPIO_OPT_PULL_DOWN) >> 1 | (pullup));
+    const uint8_t reg_val = non_settable_opt | pullen | (opt & GPIO_OPT_DRIVE_STRENGTH_STRONG);
+    PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg = reg_val;
+
+    if (pullup && pullen) {
+        PORT->Group[pin.port_num].OUTSET.reg = 1 << pin.pin_num;
+    }
+
+    const uint8_t sampling_opt_set = opt & GPIO_OPT_SAMPLE_CONTINUOUSLY;
+    uint32_t res = PORT->Group[pin.port_num].CTRL.reg;
+    if (sampling_opt_set) {
+        res |= 1 << pin.pin_num;
+        PORT->Group[pin.port_num].CTRL.reg = res;
+    } else {
+        res &= ~(1 << pin.pin_num);
+        PORT->Group[pin.port_num].CTRL.reg = res;
+    }
 }
 
-GPIOPinLevel GetGPIOPinLevel(const GPIOPin pin) {
-  return (PORT->Group[pin.port_num].IN.reg >> pin.pin_num) & 1;
-}
+gpio_opt_t get_gpio_pin_options(const gpio_pin_t pin) {
+    const uint8_t pincfg_register = PORT->Group[pin.port_num].PINCFG[pin.pin_num].reg;
+    const uint8_t pullup_en = (PORT->Group[pin.port_num].OUT.reg & (1 << pin.pin_num)) >> pin.pin_num;
+    const uint8_t pulldown_en = (pullup_en == 0) << GPIO_OPT_PULL_DOWN_POS;
+    const uint8_t sampling_opt_en = (PORT->Group[pin.port_num].CTRL.reg & (1 << pin.pin_num)) >> (pin.pin_num);
 
-GPIOPinDirection GetGPIOPinDirection(const GPIOPin pin) {
-  return (PORT->Group[pin.port_num].DIR.reg >> pin.pin_num) & 1;
-}
+    uint8_t res  = (pincfg_register & GPIO_OPT_DRIVE_STRENGTH_STRONG)  | (sampling_opt_en << GPIO_OPT_SAMPLE_CONTINUOUSLY_POS);
 
-GPIODriveStrength GetGPIODriveStrength(const GPIOPin pin) {
-  return (PORT->Group[pin.port_num].PINCFG[pin.pin_num].bit.DRVSTR);
-}
+    if (pincfg_register & PORT_PINCFG_PULLEN) {
+        res |= (pulldown_en) | (pullup_en << GPIO_OPT_PULL_UP_POS);
+        return res;
+    }
 
-GPIOPinFunction GetGPIOPinFunction(const GPIOPin pin) {
-  if (pin.pin_num % 2 == 0) {
-    return PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXE;
-  } else {
-    return PORT->Group[pin.port_num].PMUX[pin.pin_num >> 1].bit.PMUXO;
-  }
+    return res;
 }
-

--- a/hal/platform/atmelsam/i2c.c
+++ b/hal/platform/atmelsam/i2c.c
@@ -201,20 +201,20 @@ if(SlaveConfiguration) {
 	NVIC_SetPriority(irq_type, 2);
 }
 
-void i2c_deinit(const i2c_periph_inst_t* I2C_instance) {
-    disable_host_i2c_driver(I2C_instance->sercom_inst);
+void i2c_deinit(const i2c_periph_inst_t* i2c_instance) {
+    disable_host_i2c_driver(i2c_instance->sercom_inst);
 }
 
-void i2c_set_baudrate(const i2c_periph_inst_t* I2C_instance, const unsigned long baudrate) {
-    Sercom* SercomInst = I2C_instance->sercom_inst;
+void i2c_set_baudrate(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate) {
+    Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
     i2c_master_wait_for_sync(SercomInst, SERCOM_I2CM_SYNCBUSY_MASK);
     disable_host_i2c_driver(SercomInst);
-    i2c_init(I2C_instance, baudrate);
+    i2c_init(i2c_instance, baudrate);
 }
 
-void i2c_set_slave_mode(const i2c_periph_inst_t* I2C_instance, const unsigned short addr) {
-Sercom* SercomInst = I2C_instance->sercom_inst;
+void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, const unsigned short addr) {
+Sercom* SercomInst = i2c_instance->sercom_inst;
 const bool SercomEnabled = SercomInst->I2CM.CTRLA.bit.ENABLE;
 if(SercomEnabled) disable_host_i2c_driver(SercomInst);
 SercomInst->I2CS.CTRLA.reg = (SERCOM_I2CS_CTRLA_SWRST | SERCOM_I2CS_CTRLA_MODE(4));
@@ -237,10 +237,10 @@ SercomInst->I2CS.CTRLA.reg |= SERCOM_I2CS_CTRLA_ENABLE;
 SercomInst->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_AMATCH | SERCOM_I2CS_INTENSET_PREC | SERCOM_I2CS_INTENSET_DRDY;
 }
 
-void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
-    Sercom* SercomInst = I2C_instance->sercom_inst;
+void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
+    Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
-    const sercom_num_t Sercom_inst_num = I2C_instance->sercom_inst_num;
+    const sercom_num_t Sercom_inst_num = i2c_instance->sercom_inst_num;
     volatile bustransaction_t* TransactionData = &SercomBusTrans[Sercom_inst_num];
     while((SercomInst->I2CM.STATUS.bit.BUSSTATE != 0x1) && SercomBusTrans[Sercom_inst_num].transaction_type != SERCOMACT_NONE && SercomInst->I2CM.INTFLAG.reg == 0);
     i2c_master_wait_for_sync((SercomInst), SERCOM_I2CM_SYNCBUSY_SYSOP);
@@ -252,24 +252,24 @@ void i2c_write_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigne
     i2c_master_wait_for_sync((SercomInst), SERCOM_I2CM_SYNCBUSY_SYSOP);
 }
 
-void i2c_write_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned char addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
-    Sercom* SercomInst = I2C_instance->sercom_inst;
-	i2c_write_non_blocking(I2C_instance, addr, write_buff, size, stop_bit);
+void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
+    Sercom* SercomInst = i2c_instance->sercom_inst;
+	i2c_write_non_blocking(i2c_instance, addr, write_buff, size, stop_bit);
     wait_for_idle_busstate(SercomInst);
 }
 
 
 
-void i2c_read_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
-    i2c_read_non_blocking(I2C_instance, addr, read_buff, amount_of_bytes);
-    Sercom* SercomInst = I2C_instance->sercom_inst;
+void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
+    i2c_read_non_blocking(i2c_instance, addr, read_buff, amount_of_bytes);
+    Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
 }
 
-void i2c_read_non_blocking(const i2c_periph_inst_t* I2C_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
-    Sercom* SercomInst = I2C_instance->sercom_inst;
+void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
+    Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
-    const sercom_num_t Sercom_inst_num = I2C_instance->sercom_inst_num;
+    const sercom_num_t Sercom_inst_num = i2c_instance->sercom_inst_num;
     volatile bustransaction_t* TransactionData = &SercomBusTrans[Sercom_inst_num];
     i2c_master_wait_for_sync((SercomInst), SERCOM_I2CM_SYNCBUSY_SYSOP);
     TransactionData->read_buffer = read_buff;

--- a/hal/platform/atmelsam/i2c.c
+++ b/hal/platform/atmelsam/i2c.c
@@ -97,7 +97,7 @@ void wait_for_idle_busstate(Sercom *SercomInst){
      * There seems to be internal buffering inside the sercom peripheral, which seems to be stacking transactions.
      * To overcome this an extra delay has been added. Otherwise, read or write transactions will be collected and stacked
      * after each other.
-     * TODO: Change this delay to flag/checking other means of overcoming this problem
+     * @todo Change this delay to flag/checking other means of overcoming this problem
     */
     timeout = 20;
     do{
@@ -132,7 +132,7 @@ static inline void disable_host_i2c_driver(const void *const hw) {
 }
 
 
-void i2c_init(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate) {
+void i2c_init(const i2c_periph_inst_t* i2c_instance, const unsigned long baud_rate) {
     const bool InvalidSercomInstNum = (i2c_instance->sercom_inst_num < 0 || i2c_instance->sercom_inst_num > 5);
     const bool InvalidSercomInst = (i2c_instance->sercom_inst == NULL);
     const bool InvalidClockGen = (i2c_instance->clk_gen_slow < 0 || i2c_instance->clk_gen_slow > 6 || i2c_instance->clk_gen_fast < 0 || i2c_instance->clk_gen_fast > 6);
@@ -176,7 +176,7 @@ if(SlaveConfiguration) {
 	        | 5 << SERCOM_I2CM_CTRLA_MODE_Pos);
 
     i2c_master_wait_for_sync(SercomInst, SERCOM_I2CM_SYNCBUSY_MASK);
-    SercomInst->I2CM.BAUD.reg = calculate_baudrate(i2c_instance->fast_clk_gen_frequency, baudrate);
+    SercomInst->I2CM.BAUD.reg = calculate_baudrate(i2c_instance->fast_clk_gen_frequency, baud_rate);
 	int timeout         = 65535;
 	int timeout_attempt = 4;
 	SercomInst->I2CM.CTRLA.reg |= SERCOM_I2CM_CTRLA_ENABLE;
@@ -205,12 +205,12 @@ void i2c_deinit(const i2c_periph_inst_t* i2c_instance) {
     disable_host_i2c_driver(i2c_instance->sercom_inst);
 }
 
-void i2c_set_baudrate(const i2c_periph_inst_t* i2c_instance, const unsigned long baudrate) {
+void i2c_set_baud_rate(const i2c_periph_inst_t* i2c_instance, unsigned long baud_rate) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
     i2c_master_wait_for_sync(SercomInst, SERCOM_I2CM_SYNCBUSY_MASK);
     disable_host_i2c_driver(SercomInst);
-    i2c_init(i2c_instance, baudrate);
+    i2c_init(i2c_instance, baud_rate);
 }
 
 void i2c_set_slave_mode(const i2c_periph_inst_t* i2c_instance, const unsigned short addr) {
@@ -237,7 +237,7 @@ SercomInst->I2CS.CTRLA.reg |= SERCOM_I2CS_CTRLA_ENABLE;
 SercomInst->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_AMATCH | SERCOM_I2CS_INTENSET_PREC | SERCOM_I2CS_INTENSET_DRDY;
 }
 
-void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
+void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, const unsigned char* write_buff, size_t size, unsigned char stop_bit) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
     const sercom_num_t Sercom_inst_num = i2c_instance->sercom_inst_num;
@@ -252,7 +252,7 @@ void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigne
     i2c_master_wait_for_sync((SercomInst), SERCOM_I2CM_SYNCBUSY_SYSOP);
 }
 
-void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr, const unsigned char* write_buff, const unsigned char size, bool stop_bit) {
+void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr, const unsigned char* write_buff, size_t size, unsigned char stop_bit) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
 	i2c_write_non_blocking(i2c_instance, addr, write_buff, size, stop_bit);
     wait_for_idle_busstate(SercomInst);
@@ -260,13 +260,13 @@ void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned ch
 
 
 
-void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
+void i2c_read_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, size_t amount_of_bytes) {
     i2c_read_non_blocking(i2c_instance, addr, read_buff, amount_of_bytes);
     Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
 }
 
-void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, const unsigned char amount_of_bytes) {
+void i2c_read_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, unsigned char* read_buff, size_t amount_of_bytes) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
     const sercom_num_t Sercom_inst_num = i2c_instance->sercom_inst_num;

--- a/hal/platform/atmelsam/i2c.c
+++ b/hal/platform/atmelsam/i2c.c
@@ -1,23 +1,31 @@
+/**
+* \file            i2c.c
+* \brief           Source file which implements the standard I2C API functions
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #include <stdbool.h>
 #include <hal_i2c.h>
 #include <stddef.h>
-#include <atmel_default_irq_handlers.h>
+#include <default_irq_handlers.h>
 
 /**
  * @brief This formula is used to calculate the baud rate steps.

--- a/hal/platform/atmelsam/i2c.c
+++ b/hal/platform/atmelsam/i2c.c
@@ -237,7 +237,7 @@ SercomInst->I2CS.CTRLA.reg |= SERCOM_I2CS_CTRLA_ENABLE;
 SercomInst->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_AMATCH | SERCOM_I2CS_INTENSET_PREC | SERCOM_I2CS_INTENSET_DRDY;
 }
 
-void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, const unsigned char* write_buff, size_t size, unsigned char stop_bit) {
+void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned short addr, const unsigned char* write_buff, size_t size, i2c_stop_bit_t stop_bit) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
     wait_for_idle_busstate(SercomInst);
     const sercom_num_t Sercom_inst_num = i2c_instance->sercom_inst_num;
@@ -252,7 +252,7 @@ void i2c_write_non_blocking(const i2c_periph_inst_t* i2c_instance, const unsigne
     i2c_master_wait_for_sync((SercomInst), SERCOM_I2CM_SYNCBUSY_SYSOP);
 }
 
-void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr, const unsigned char* write_buff, size_t size, unsigned char stop_bit) {
+void i2c_write_blocking(const i2c_periph_inst_t* i2c_instance, const unsigned char addr, const unsigned char* write_buff, size_t size, i2c_stop_bit_t stop_bit) {
     Sercom* SercomInst = i2c_instance->sercom_inst;
 	i2c_write_non_blocking(i2c_instance, addr, write_buff, size, stop_bit);
     wait_for_idle_busstate(SercomInst);

--- a/hal/platform/atmelsam/i2c_platform_specific.h
+++ b/hal/platform/atmelsam/i2c_platform_specific.h
@@ -1,18 +1,26 @@
+/**
+* \file            i2c_platform_specific.h
+* \brief           Include file with platform specific options for the I2C module
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #ifndef I2C_MASTER_PLATFORM_SPECIFIC
 #define I2C_MASTER_PLATFORM_SPECIFIC

--- a/hal/platform/atmelsam/i2c_platform_specific.h
+++ b/hal/platform/atmelsam/i2c_platform_specific.h
@@ -24,44 +24,28 @@
 
 #ifndef I2C_MASTER_PLATFORM_SPECIFIC
 #define I2C_MASTER_PLATFORM_SPECIFIC
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 #include <sam.h>
 #include <stddef.h>
 
-typedef enum {
-    I2COpModeMaster,
-    I2COpModeSlave
-} i2c_operating_mode_t;
+typedef enum { I2COpModeMaster, I2COpModeSlave } i2c_operating_mode_t;
 
-typedef enum {
-    SERCOM_NUM_0,
-    SERCOM_NUM_1,
-    SERCOM_NUM_2,
-    SERCOM_NUM_3,
-    SERCOM_NUM_4,
-    SERCOM_NUM_5
-} sercom_num_t;
+typedef enum { SERCOM_NUM_0, SERCOM_NUM_1, SERCOM_NUM_2, SERCOM_NUM_3, SERCOM_NUM_4, SERCOM_NUM_5 } sercom_num_t;
 
-typedef enum {
-    CLKGEN_0,
-    CLKGEN_1,
-    CLKGEN_2,
-    CLKGEN_3,
-    CLKGEN_4,
-    CLKGEN_5,
-    CLKGEN_6,
-    CLKGEN_7,
-    CLKGEN_8
-} clk_gen_num_t;
+typedef enum { CLKGEN_0, CLKGEN_1, CLKGEN_2, CLKGEN_3, CLKGEN_4, CLKGEN_5, CLKGEN_6, CLKGEN_7, CLKGEN_8 } clk_gen_num_t;
 
 typedef struct {
-sercom_num_t sercom_inst_num;
-Sercom* sercom_inst;
-clk_gen_num_t clk_gen_slow;
-clk_gen_num_t clk_gen_fast;
-uint32_t fast_clk_gen_frequency;
-i2c_operating_mode_t operating_mode;
-unsigned short i2c_slave_addr;
+    sercom_num_t sercom_inst_num;
+    Sercom* sercom_inst;
+    clk_gen_num_t clk_gen_slow;
+    clk_gen_num_t clk_gen_fast;
+    uint32_t fast_clk_gen_frequency;
+    i2c_operating_mode_t operating_mode;
+    unsigned short i2c_slave_addr;
 } i2c_periph_inst_t;
 
 typedef struct {
@@ -80,8 +64,9 @@ typedef enum {
     SERCOMACT_I2C_DATA_TRANSMIT_NO_STOP,
     SERCOMACT_I2C_DATA_TRANSMIT_STOP,
     SERCOMACT_I2C_DATA_RECEIVE_STOP
-}busactions_t;
+} busactions_t;
 
-
-
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/platform/raspberrypi/gpio_platform_specific.h
+++ b/hal/platform/raspberrypi/gpio_platform_specific.h
@@ -31,17 +31,9 @@ extern "C" {
 
 #include <gpio.h>
 
-#define SUPPORT_PIN_PULL                 1
-#define HAS_NO_GPIO_PORT_DESIGNATORS     1
-#define SUPPORT_DRIVE_STRENGTH_SETTING   1
-#define SUPPORT_PINMUX                   1
-#define SUPPORT_PIN_TOGGLE               1
-#define SUPPORT_PIN_SAMPLING_MODE_SELECT 0
-
-#define GPIODriveStrength                enum gpio_drive_strength
-
-#define GPIOPinFunction                  enum gpio_function
-
+/*
+ * @todo RASPBERRY PI PICO NEEDS COMPLETE REWORK!
+ */
 typedef enum { kGPIOPullBusKeep, kGPIOPullDown, kGPIOPullUp, kGPIONoPull } GPIOPull;
 
 typedef struct {

--- a/hal/platform/raspberrypi/gpio_platform_specific.h
+++ b/hal/platform/raspberrypi/gpio_platform_specific.h
@@ -22,31 +22,33 @@
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
 
-
 #ifndef GPIO_PLATFORM_SPECIFIC
 #define GPIO_PLATFORM_SPECIFIC
+/* Extern c for compiling with c++*/
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <gpio.h>
 
-#define SUPPORT_PIN_PULL 1
-#define HAS_NO_GPIO_PORT_DESIGNATORS 1
-#define SUPPORT_DRIVE_STRENGTH_SETTING 1
-#define SUPPORT_PINMUX 1
-#define SUPPORT_PIN_TOGGLE 1
+#define SUPPORT_PIN_PULL                 1
+#define HAS_NO_GPIO_PORT_DESIGNATORS     1
+#define SUPPORT_DRIVE_STRENGTH_SETTING   1
+#define SUPPORT_PINMUX                   1
+#define SUPPORT_PIN_TOGGLE               1
 #define SUPPORT_PIN_SAMPLING_MODE_SELECT 0
 
-#define GPIODriveStrength enum gpio_drive_strength
+#define GPIODriveStrength                enum gpio_drive_strength
 
-#define GPIOPinFunction enum gpio_function
+#define GPIOPinFunction                  enum gpio_function
 
-typedef enum {
-  kGPIOPullBusKeep,
-  kGPIOPullDown,
-  kGPIOPullUp,
-  kGPIONoPull
-} GPIOPull;
-
+typedef enum { kGPIOPullBusKeep, kGPIOPullDown, kGPIOPullUp, kGPIONoPull } GPIOPull;
 
 typedef struct {
-  unsigned char pin_num;
+    unsigned char pin_num;
 } GPIOPin;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif

--- a/hal/platform/raspberrypi/gpio_raspberrypi.c
+++ b/hal/platform/raspberrypi/gpio_raspberrypi.c
@@ -26,15 +26,18 @@
 #include <gpio_platform_specific.h>
 #include <gpio.h>
 
-void SetGPIOPinDriveStrength(const GPIOPin pin, GPIODriveStrength driver_strength) {
+void
+set_gpio_pin_driver_strength(const GPIOPin pin, GPIODriveStrength driver_strength) {
     gpio_set_drive_strength(pin.pin_num, driver_strength);
 }
 
-GPIODriveStrength GetGPIODriveStrength(const GPIOPin pin) {
+GPIODriveStrength
+get_gpio_driver_strength(const GPIOPin pin) {
     return gpio_get_drive_strength(pin.pin_num);
 }
 
-void SetGPIOPinFunction(const GPIOPin pin, GPIOPinFunction pin_function) {
+void
+set_gpio_pin_function(const GPIOPin pin, GPIOPinFunction pin_function) {
     gpio_set_function(pin.pin_num, pin_function);
 }
 
@@ -44,28 +47,32 @@ void SetGPIOPull(const GPIOPin pin, GPIOPull PullMode) {
     gpio_set_pulls(pin.pin_num, up, down);
 }
 
-GPIOPinFunction GetGPIOPinFunction(const GPIOPin pin) {
+GPIOPinFunction
+get_gpio_pin_function(const GPIOPin pin) {
 return gpio_get_function(pin.pin_num);
 }
 
-void SetGPIOPinDirection(const GPIOPin pin, const unsigned char direction) {
+void set_gpio_pin_mode(const gpio_pin_t pin, const unsigned char direction) {
 gpio_set_function(pin.pin_num, GPIO_FUNC_SIO);
 gpio_set_dir(pin.pin_num, direction);
 }
 
-void SetGPIOPinLevel(const GPIOPin pin, const unsigned char level) {
+void set_gpio_pin_lvl(const GPIOPin pin, const unsigned char level) {
 gpio_put(pin.pin_num, level);
 }
 
-GPIOPinDirection GetGPIOPinDirection(const GPIOPin pin) {
+GPIOPinDirection
+get_gpio_pin_direction(const GPIOPin pin) {
 return gpio_get_dir(pin.pin_num);
 }
 
-GPIOPinLevel GetGPIOPinLevel(GPIOPin pin) {
+GPIOPinLevel
+get_gpio_pin_level(const GPIOPin pin) {
     return gpio_get(pin.pin_num);
 }
 
-void ToggleGPIOPin(const GPIOPin pin) {
+void
+toggle_gpio_pin_output(const GPIOPin pin) {
     uint32_t mask = 1ul << pin.pin_num;
     gpio_xor_mask(mask);
 }

--- a/hal/platform/raspberrypi/gpio_raspberrypi.c
+++ b/hal/platform/raspberrypi/gpio_raspberrypi.c
@@ -22,22 +22,19 @@
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
 
-#include <hal_gpio.h>
-#include <gpio_platform_specific.h>
 #include <gpio.h>
+#include <gpio_platform_specific.h>
+#include <hal_gpio.h>
 
-void
-set_gpio_pin_driver_strength(const GPIOPin pin, GPIODriveStrength driver_strength) {
+void set_gpio_pin_driver_strength(const GPIOPin pin, GPIODriveStrength driver_strength) {
     gpio_set_drive_strength(pin.pin_num, driver_strength);
 }
 
-GPIODriveStrength
-get_gpio_driver_strength(const GPIOPin pin) {
+GPIODriveStrength get_gpio_driver_strength(const GPIOPin pin) {
     return gpio_get_drive_strength(pin.pin_num);
 }
 
-void
-set_gpio_pin_function(const GPIOPin pin, GPIOPinFunction pin_function) {
+void set_gpio_pin_function(const GPIOPin pin, GPIOPinFunction pin_function) {
     gpio_set_function(pin.pin_num, pin_function);
 }
 
@@ -47,33 +44,28 @@ void SetGPIOPull(const GPIOPin pin, GPIOPull PullMode) {
     gpio_set_pulls(pin.pin_num, up, down);
 }
 
-GPIOPinFunction
-get_gpio_pin_function(const GPIOPin pin) {
-return gpio_get_function(pin.pin_num);
+GPIOPinFunction get_gpio_pin_function(const GPIOPin pin) {
+    return gpio_get_function(pin.pin_num);
 }
 
 void set_gpio_pin_mode(const gpio_pin_t pin, const unsigned char direction) {
-gpio_set_function(pin.pin_num, GPIO_FUNC_SIO);
-gpio_set_dir(pin.pin_num, direction);
+    gpio_set_function(pin.pin_num, GPIO_FUNC_SIO);
+    gpio_set_dir(pin.pin_num, direction);
 }
 
 void set_gpio_pin_lvl(const GPIOPin pin, const unsigned char level) {
-gpio_put(pin.pin_num, level);
+    gpio_put(pin.pin_num, level);
 }
 
-GPIOPinDirection
-get_gpio_pin_direction(const GPIOPin pin) {
-return gpio_get_dir(pin.pin_num);
+GPIOPinDirection get_gpio_pin_direction(const GPIOPin pin) {
+    return gpio_get_dir(pin.pin_num);
 }
 
-GPIOPinLevel
-get_gpio_pin_level(const GPIOPin pin) {
+GPIOPinLevel get_gpio_pin_level(const GPIOPin pin) {
     return gpio_get(pin.pin_num);
 }
 
-void
-toggle_gpio_pin_output(const GPIOPin pin) {
+void toggle_gpio_pin_output(const GPIOPin pin) {
     uint32_t mask = 1ul << pin.pin_num;
     gpio_xor_mask(mask);
 }
-

--- a/hal/platform/raspberrypi/gpio_raspberrypi.c
+++ b/hal/platform/raspberrypi/gpio_raspberrypi.c
@@ -1,18 +1,26 @@
+/**
+* \file            gpio_samd.c
+* \brief           Source file which implements the standard GPIO API functions
+*/
 /*
- *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+*  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+* This file is part of the Universal Hal Framework.
+*
+* Author:          Victor Hogeweij <hogeweyv@gmail.com>
+*/
 
 #include <hal_gpio.h>
 #include <gpio_platform_specific.h>

--- a/hal/universal_hal.h
+++ b/hal/universal_hal.h
@@ -25,15 +25,16 @@
 #ifndef ATMELSAMD21_UNIVERSAL_HAL_H
 #define ATMELSAMD21_UNIVERSAL_HAL_H
 
+/* Extern c for compiling with c++*/
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* __cplusplus */
 
-#include "hal_i2c.h"
 #include "hal_gpio.h"
+#include "hal_i2c.h"
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* __cplusplus */
 
 #endif //ATMELSAMD21_UNIVERSAL_HAL_H

--- a/hal/universal_hal.h
+++ b/hal/universal_hal.h
@@ -1,6 +1,6 @@
 /**
-* \file            gpio_platform_specific.h
-* \brief           Include file with peripheral specific settings for the GPIO module
+* \file            universal_hal.h
+* \brief           Universal hal modules include file
 */
 /*
 *  Copyright 2023 (C) Victor Hogeweij <hogeweyv@gmail.com>
@@ -22,31 +22,18 @@
 * Author:          Victor Hogeweij <hogeweyv@gmail.com>
 */
 
+#ifndef ATMELSAMD21_UNIVERSAL_HAL_H
+#define ATMELSAMD21_UNIVERSAL_HAL_H
 
-#ifndef GPIO_PLATFORM_SPECIFIC
-#define GPIO_PLATFORM_SPECIFIC
-#include <gpio.h>
-
-#define SUPPORT_PIN_PULL 1
-#define HAS_NO_GPIO_PORT_DESIGNATORS 1
-#define SUPPORT_DRIVE_STRENGTH_SETTING 1
-#define SUPPORT_PINMUX 1
-#define SUPPORT_PIN_TOGGLE 1
-#define SUPPORT_PIN_SAMPLING_MODE_SELECT 0
-
-#define GPIODriveStrength enum gpio_drive_strength
-
-#define GPIOPinFunction enum gpio_function
-
-typedef enum {
-  kGPIOPullBusKeep,
-  kGPIOPullDown,
-  kGPIOPullUp,
-  kGPIONoPull
-} GPIOPull;
-
-
-typedef struct {
-  unsigned char pin_num;
-} GPIOPin;
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+#include "hal_i2c.h"
+#include "hal_gpio.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //ATMELSAMD21_UNIVERSAL_HAL_H


### PR DESCRIPTION
Yesterday a code style guide was added to the repository. To view this look at the [wiki](https://hoog-v.github.io/Universal_hal/code_style/#code-style). 

The I2C module is still not compliant, but to make some progress I first started completely refactoring the GPIO hal for the SAMD which had terrible names and API. 

I would like a honest review... A good API is very important for cross-platform compatibility.

I have added and changed some functionality:
- Added an auto formatter file for clangd (.clang-format file)
- Interrupt functionality for GPIO module
- Better support for setting gpio functions (pin-mux, input or output), now it is somewhat similair to Arduino's approach (pinMode function) but much more lightweight.
-  Improved naming according to naming convention from style guide.
-  Improved api for setting options like pull-ups and pull-downs
- Add better license banners and add include guards for compiling with cpp compiler